### PR TITLE
Full Frontal Phantasm

### DIFF
--- a/animations/pom.xml
+++ b/animations/pom.xml
@@ -17,6 +17,14 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>javax.jms</groupId>
+            <artifactId>jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>opensymphony</groupId>
+            <artifactId>oscache</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.chiralbehaviors.CoRE</groupId>
             <artifactId>thing-ontology</artifactId>
             <scope>test</scope>

--- a/animations/pom.xml
+++ b/animations/pom.xml
@@ -17,14 +17,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>opensymphony</groupId>
-            <artifactId>oscache</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.chiralbehaviors.CoRE</groupId>
             <artifactId>thing-ontology</artifactId>
             <scope>test</scope>

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/NetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/NetworkedModel.java
@@ -584,10 +584,11 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
     /**
      * Propagate the network inferences based on the tracked additions,
      * deletions and modifications
+     * @param initial TODO
      *
      * @throws SQLException
      */
-    void propagate();
+    void propagate(boolean initial);
 
     /**
      * Sets a value for an attribute after validating it first

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
@@ -1279,8 +1279,8 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
     }
 
     @Override
-    public void propagate() {
-        createDeductionTemporaryTables();
+    public void propagate(boolean initial) {
+        createDeductionTemporaryTables(initial);
         boolean firstPass = true;
         do {
             if (infer(firstPass) == 0) {
@@ -1441,10 +1441,12 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
           .executeUpdate();
     }
 
-    private void createDeductionTemporaryTables() {
-        createWorkingMemory();
-        createCurrentPassRules();
-        createLastPassRules();
+    private void createDeductionTemporaryTables(boolean initial) {
+        if (initial) {
+            createWorkingMemory();
+            createCurrentPassRules();
+            createLastPassRules();
+        }
         em.createNativeQuery("TRUNCATE working_memory")
           .executeUpdate();
         em.createNativeQuery("TRUNCATE current_pass_rules")

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
@@ -1249,7 +1249,8 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
     public void initialize(RuleForm instance,
                            NetworkAuthorization<RuleForm> facet,
                            Agency principal) {
-        // TODO Auto-generated method stub
+        initialize(instance, new Aspect<RuleForm>(facet.getClassifier(),
+                                                  facet.getClassification()));
 
     }
 

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
@@ -1431,7 +1431,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
     }
 
     private void createCurrentPassRules() {
-        em.createNativeQuery("CREATE TEMPORARY TABLE current_pass_rules ("
+        em.createNativeQuery("CREATE TEMPORARY TABLE IF NOT EXISTS current_pass_rules ("
                              + "id uuid NOT NULL," + "parent uuid NOT NULL,"
                              + "relationship uuid NOT NULL,"
                              + "child uuid NOT NULL,"
@@ -1442,19 +1442,19 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
     }
 
     private void createDeductionTemporaryTables() {
-        em.createNativeQuery("DROP TABLE IF EXISTS last_pass_rules")
-          .executeUpdate();
-        em.createNativeQuery("DROP TABLE IF EXISTS current_pass_rules")
-          .executeUpdate();
-        em.createNativeQuery("DROP TABLE IF EXISTS working_memory")
-          .executeUpdate();
         createWorkingMemory();
         createCurrentPassRules();
         createLastPassRules();
+        em.createNativeQuery("TRUNCATE working_memory")
+          .executeUpdate();
+        em.createNativeQuery("TRUNCATE current_pass_rules")
+          .executeUpdate();
+        em.createNativeQuery("TRUNCATE last_pass_rules")
+          .executeUpdate();
     }
 
     private void createLastPassRules() {
-        em.createNativeQuery("CREATE TEMPORARY TABLE last_pass_rules ("
+        em.createNativeQuery("CREATE TEMPORARY TABLE IF NOT EXISTS last_pass_rules ("
                              + "id uuid NOT NULL," + "parent uuid NOT NULL,"
                              + "relationship uuid NOT NULL,"
                              + "child uuid NOT NULL,"
@@ -1465,7 +1465,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
     }
 
     private void createWorkingMemory() {
-        em.createNativeQuery("CREATE TEMPORARY TABLE working_memory("
+        em.createNativeQuery("CREATE TEMPORARY TABLE IF NOT EXISTS working_memory("
                              + "parent uuid NOT NULL,"
                              + "relationship uuid NOT NULL,"
                              + "child uuid NOT NULL,"

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/Animations.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/Animations.java
@@ -260,7 +260,8 @@ public class Animations implements Triggers {
     public void flush() {
         em.flush();
         try {
-            model.getJobModel().validateStateGraph(modifiedServices);
+            model.getJobModel()
+                 .validateStateGraph(modifiedServices);
         } catch (SQLException e) {
             throw new TriggerException("StatusCodeSequencing validation failed",
                                        e);
@@ -298,7 +299,8 @@ public class Animations implements Triggers {
     }
 
     public void inferNetworks(ExistentialRuleform<?, ?> ruleform) {
-        switch (ruleform.getClass().getSimpleName()) {
+        switch (ruleform.getClass()
+                        .getSimpleName()) {
             case "Agency":
                 inferAgencyNetwork = true;
                 return;
@@ -482,34 +484,51 @@ public class Animations implements Triggers {
     private void process(Job j) {
         JobModel jobModel = model.getJobModel();
         jobModel.generateImplicitJobsForExplicitJobs(j,
-                                                     model.getCurrentPrincipal().getPrincipal());
+                                                     model.getCurrentPrincipal()
+                                                          .getPrincipal());
         jobModel.processJobSequencing(j);
     }
 
     private void propagate() {
+        boolean initial = true;
         if (inferAgencyNetwork) {
-            model.getAgencyModel().propagate();
+            model.getAgencyModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferAttributeNetwork) {
-            model.getAttributeModel().propagate();
+            model.getAttributeModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferIntervalNetwork) {
-            model.getIntervalModel().propagate();
+            model.getIntervalModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferLocationNetwork) {
-            model.getLocationModel().propagate();
+            model.getLocationModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferProductNetwork) {
-            model.getProductModel().propagate();
+            model.getProductModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferRelationshipNetwork) {
-            model.getRelationshipModel().propagate();
+            model.getRelationshipModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferStatusCodeNetwork) {
-            model.getStatusCodeModel().propagate();
+            model.getStatusCodeModel()
+                 .propagate(initial);
+            initial = false;
         }
         if (inferUnitNetwork) {
-            model.getUnitModel().propagate();
+            model.getUnitModel()
+                 .propagate(initial);
         }
     }
 
@@ -540,8 +559,9 @@ public class Animations implements Triggers {
         for (ProductChildSequencingAuthorization pcsa : childSequences) {
 
             try {
-                model.getJobModel().ensureValidServiceAndStatus(pcsa.getNextChild(),
-                                                                pcsa.getNextChildStatus());
+                model.getJobModel()
+                     .ensureValidServiceAndStatus(pcsa.getNextChild(),
+                                                  pcsa.getNextChildStatus());
             } catch (SQLException e) {
                 throw new TriggerException(String.format("Invalid sequence: %s",
                                                          pcsa),
@@ -553,19 +573,22 @@ public class Animations implements Triggers {
     private void validateEnums() {
         for (AttributeValue<?> value : attributeValues) {
             Attribute attribute = value.getAttribute();
-            Attribute validatingAttribute = model.getAttributeModel().getSingleChild(attribute,
-                                                                                     model.getKernel().getIsValidatedBy());
+            Attribute validatingAttribute = model.getAttributeModel()
+                                                 .getSingleChild(attribute,
+                                                                 model.getKernel()
+                                                                      .getIsValidatedBy());
             if (validatingAttribute != null) {
-                List<AttributeMetaAttribute> attrs = model.getAttributeModel().getAttributeValues(validatingAttribute,
-                                                                                                  attribute);
+                List<AttributeMetaAttribute> attrs = model.getAttributeModel()
+                                                          .getAttributeValues(validatingAttribute,
+                                                                              attribute);
                 if (attrs == null || attrs.size() == 0) {
                     throw new IllegalArgumentException("No valid values for attribute "
                                                        + attribute.getName());
                 }
                 boolean valid = false;
                 for (AttributeMetaAttribute ama : attrs) {
-                    if (ama.getTextValue() != null
-                        && ama.getTextValue().equals(value.getTextValue())) {
+                    if (ama.getTextValue() != null && ama.getTextValue()
+                                                         .equals(value.getTextValue())) {
                         valid = true;
                         break;
                     }
@@ -582,8 +605,9 @@ public class Animations implements Triggers {
     private void validateParentSequencing() {
         for (ProductParentSequencingAuthorization ppsa : parentSequences) {
             try {
-                model.getJobModel().ensureValidServiceAndStatus(ppsa.getParent(),
-                                                                ppsa.getParentStatusToSet());
+                model.getJobModel()
+                     .ensureValidServiceAndStatus(ppsa.getParent(),
+                                                  ppsa.getParentStatusToSet());
             } catch (SQLException e) {
                 throw new TriggerException("Invalid sequence", e);
             }
@@ -593,8 +617,9 @@ public class Animations implements Triggers {
     private void validateSelfSequencing() {
         for (ProductSelfSequencingAuthorization pssa : selfSequences) {
             try {
-                model.getJobModel().ensureValidServiceAndStatus(pssa.getService(),
-                                                                pssa.getStatusToSet());
+                model.getJobModel()
+                     .ensureValidServiceAndStatus(pssa.getService(),
+                                                  pssa.getStatusToSet());
             } catch (SQLException e) {
                 throw new TriggerException("Invalid sequence", e);
             }
@@ -611,8 +636,9 @@ public class Animations implements Triggers {
     private void validateSiblingSequencing() {
         for (ProductSiblingSequencingAuthorization pssa : siblingSequences) {
             try {
-                model.getJobModel().ensureValidServiceAndStatus(pssa.getNextSibling(),
-                                                                pssa.getNextSiblingStatus());
+                model.getJobModel()
+                     .ensureValidServiceAndStatus(pssa.getNextSibling(),
+                                                  pssa.getNextSiblingStatus());
             } catch (SQLException e) {
                 throw new TriggerException("Invalid sequence", e);
             }

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -80,11 +80,45 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
-        checkREAD(child, networkedModel);
 
         networkedModel.link(instance, auth.getAuthorizedRelationship(), child,
                             model.getCurrentPrincipal()
                                  .getPrincipal());
+        return instance;
+    }
+
+    public RuleForm addChild(RuleForm instance,
+                             XDomainNetworkAuthorization<?, ?> auth,
+                             @SuppressWarnings("rawtypes") ExistentialRuleform child) {
+        if (instance == null) {
+            return null;
+        }
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
+        checkUPDATE(auth, networkedModel);
+        NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
+                                                                         model)
+                                                             : resolveFrom(auth,
+                                                                           model);
+        if (childAuth.getClassification() instanceof Agency) {
+            networkedModel.authorize(instance, auth.getConnection(),
+                                     (Agency) child);
+        } else if (childAuth.getClassification() instanceof Location) {
+            networkedModel.authorize(instance, auth.getConnection(),
+                                     (Location) child);
+        } else if (childAuth.getClassification() instanceof Product) {
+            networkedModel.authorize(instance, auth.getConnection(),
+                                     (Product) child);
+        } else if (childAuth.getClassification() instanceof Relationship) {
+            networkedModel.authorize(instance, auth.getConnection(),
+                                     (Relationship) child);
+        } else {
+            throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
+                                                             instance.getClass()
+                                                                     .getSimpleName(),
+                                                             childAuth.getClassification()
+                                                                      .getClass()
+                                                                      .getSimpleName()));
+        }
         return instance;
     }
 
@@ -108,6 +142,44 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             networkedModel.link(instance, auth.getAuthorizedRelationship(),
                                 child, model.getCurrentPrincipal()
                                             .getPrincipal());
+        }
+        return instance;
+    }
+
+    public RuleForm addChildren(RuleForm instance,
+                                XDomainNetworkAuthorization<?, ?> auth,
+                                @SuppressWarnings("rawtypes") List<ExistentialRuleform> children) {
+        if (instance == null) {
+            return null;
+        }
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
+        checkUPDATE(auth, networkedModel);
+        NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
+                                                                         model)
+                                                             : resolveFrom(auth,
+                                                                           model);
+        for (@SuppressWarnings("rawtypes")
+        ExistentialRuleform child : children) {
+            if (childAuth.getClassification() instanceof Agency) {
+                networkedModel.authorize(instance, auth.getConnection(),
+                                         (Agency) child);
+            } else if (childAuth.getClassification() instanceof Location) {
+                networkedModel.authorize(instance, auth.getConnection(),
+                                         (Location) child);
+            } else if (childAuth.getClassification() instanceof Product) {
+                networkedModel.authorize(instance, auth.getConnection(),
+                                         (Product) child);
+            } else if (childAuth.getClassification() instanceof Relationship) {
+                networkedModel.authorize(instance, auth.getConnection(),
+                                         (Relationship) child);
+            } else {
+                throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
+                                                                 instance.getClass()
+                                                                         .getSimpleName(),
+                                                                 childAuth.getClassification()
+                                                                          .getClass()
+                                                                          .getSimpleName()));
+            }
         }
         return instance;
     }
@@ -233,17 +305,15 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Answer the xd children of the instance
      * 
      * @param instance
-     * @param facet
      * @param auth
      * @return
      */
     public List<?> getChildren(RuleForm instance,
-                               NetworkAuthorization<RuleForm> facet,
                                XDomainNetworkAuthorization<?, ?> auth) {
         if (instance == null) {
             return Collections.emptyList();
         }
-        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
+        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkREAD(auth, networkedModel);
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
                                                                          model)
@@ -265,8 +335,11 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                                                auth.getConnection());
         } else {
             throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
-                                                             facet.getClassification(),
-                                                             childAuth.getClassification()));
+                                                             instance.getClass()
+                                                                     .getSimpleName(),
+                                                             childAuth.getClassification()
+                                                                      .getClass()
+                                                                      .getSimpleName()));
         }
         NetworkedModel<?, ?, ?, ?> childNetworkModel = model.getUnknownNetworkedModel(childAuth.getClassification());
         return result.stream()
@@ -348,17 +421,15 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Answer the singular xd child of the instance
      * 
      * @param instance
-     * @param facet
      * @param auth
      * @return
      */
     public Object getSingularChild(RuleForm instance,
-                                   NetworkAuthorization<RuleForm> facet,
                                    XDomainNetworkAuthorization<?, ?> auth) {
         if (instance == null) {
             return null;
         }
-        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
+        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkREAD(auth, networkedModel);
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
                                                                          model)
@@ -380,8 +451,11 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                                              auth.getConnection());
         } else {
             throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
-                                                             facet.getClassification(),
-                                                             childAuth.getClassification()));
+                                                             instance.getClass()
+                                                                     .getSimpleName(),
+                                                             childAuth.getClassification()
+                                                                      .getClass()
+                                                                      .getSimpleName()));
         }
         checkREAD(child,
                   model.getUnknownNetworkedModel(childAuth.getClassification()));
@@ -392,6 +466,20 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public List<ExistentialRuleform> lookup(NetworkAuthorization auth,
                                             List<String> ids) {
         NetworkedModel<?, ?, ?, ?> networkedModel = model.getUnknownNetworkedModel(auth.getClassification());
+        return ids.stream()
+                  .map(id -> networkedModel.find(UUID.fromString(id)))
+                  .filter(rf -> rf != null)
+                  .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                                       .getPrincipal(),
+                                                                  child,
+                                                                  model.getKernel()
+                                                                       .getREAD()))
+                  .collect(Collectors.toList());
+    }
+
+    public List<RuleForm> lookupRuleForm(NetworkAuthorization<RuleForm> auth,
+                                         List<String> ids) {
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         return ids.stream()
                   .map(id -> networkedModel.find(UUID.fromString(id)))
                   .filter(rf -> rf != null)
@@ -462,6 +550,41 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
+    public RuleForm removeChild(RuleForm instance,
+                                XDomainNetworkAuthorization<?, ?> auth,
+                                @SuppressWarnings("rawtypes") ExistentialRuleform child) {
+        if (instance == null) {
+            return null;
+        }
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
+        checkUPDATE(auth, networkedModel);
+        NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
+                                                                         model)
+                                                             : resolveFrom(auth,
+                                                                           model);
+        if (childAuth.getClassification() instanceof Agency) {
+            networkedModel.deauthorize(instance, auth.getConnection(),
+                                       (Agency) child);
+        } else if (childAuth.getClassification() instanceof Location) {
+            networkedModel.deauthorize(instance, auth.getConnection(),
+                                       (Location) child);
+        } else if (childAuth.getClassification() instanceof Product) {
+            networkedModel.deauthorize(instance, auth.getConnection(),
+                                       (Product) child);
+        } else if (childAuth.getClassification() instanceof Relationship) {
+            networkedModel.deauthorize(instance, auth.getConnection(),
+                                       (Relationship) child);
+        } else {
+            throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
+                                                             instance.getClass()
+                                                                     .getSimpleName(),
+                                                             childAuth.getClassification()
+                                                                      .getClass()
+                                                                      .getSimpleName()));
+        }
+        return instance;
+    }
+
     /**
      * Remove the immediate child links from the instance
      * 
@@ -469,9 +592,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * @param auth
      * @param children
      */
-    public RuleForm removeImmediateChildren(RuleForm instance,
-                                            NetworkAuthorization<RuleForm> auth,
-                                            List<RuleForm> children) {
+    public RuleForm removeChildren(RuleForm instance,
+                                   NetworkAuthorization<RuleForm> auth,
+                                   List<RuleForm> children) {
         if (instance == null) {
             return null;
         }
@@ -484,6 +607,43 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             if (link != null) {
                 model.getEntityManager()
                      .remove(link);
+            }
+        }
+        return instance;
+    }
+
+    public RuleForm removeChildren(RuleForm instance,
+                                   XDomainNetworkAuthorization<?, ?> auth,
+                                   @SuppressWarnings("rawtypes") List<ExistentialRuleform> children) {
+        if (instance == null) {
+            return null;
+        }
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
+        checkUPDATE(auth, networkedModel);
+        NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
+                                                                         model)
+                                                             : resolveFrom(auth,
+                                                                           model);
+        for (ExistentialRuleform<?, ?> child : children) {
+            if (childAuth.getClassification() instanceof Agency) {
+                networkedModel.deauthorize(instance, auth.getConnection(),
+                                           (Agency) child);
+            } else if (childAuth.getClassification() instanceof Location) {
+                networkedModel.deauthorize(instance, auth.getConnection(),
+                                           (Location) child);
+            } else if (childAuth.getClassification() instanceof Product) {
+                networkedModel.deauthorize(instance, auth.getConnection(),
+                                           (Product) child);
+            } else if (childAuth.getClassification() instanceof Relationship) {
+                networkedModel.deauthorize(instance, auth.getConnection(),
+                                           (Relationship) child);
+            } else {
+                throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
+                                                                 instance.getClass()
+                                                                         .getSimpleName(),
+                                                                 childAuth.getClassification()
+                                                                          .getClass()
+                                                                          .getSimpleName()));
             }
         }
         return instance;
@@ -542,29 +702,23 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Set the xd children of the instance.
      * 
      * @param instance
-     * @param facet
      * @param auth
      * @param children
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({ "unchecked" })
     public RuleForm setChildren(RuleForm instance,
-                                NetworkAuthorization<RuleForm> facet,
                                 XDomainNetworkAuthorization<?, ?> auth,
                                 List<?> children) {
-        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
+        if (instance == null) {
+            return null;
+        }
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkUPDATE(auth, networkedModel);
         checkREAD(instance, networkedModel);
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
                                                                          model)
                                                              : resolveFrom(auth,
                                                                            model);
-        NetworkedModel<?, ?, ?, ?> childNetworkedModel = null;
-        for (ExistentialRuleform child : (List<ExistentialRuleform>) children) {
-            if (childNetworkedModel == null) {
-                childNetworkedModel = model.getUnknownNetworkedModel(child);
-            }
-            checkREAD(child, childNetworkedModel);
-        }
         if (childAuth.getClassification() instanceof Agency) {
             networkedModel.setAuthorizedAgencies(instance, auth.getConnection(),
                                                  (List<Agency>) children);
@@ -581,8 +735,11 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                                       (List<Relationship>) children);
         } else {
             throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
-                                                             facet.getClassification(),
-                                                             childAuth.getClassification()));
+                                                             instance.getClass()
+                                                                     .getSimpleName(),
+                                                             childAuth.getClassification()
+                                                                      .getClass()
+                                                                      .getSimpleName()));
         }
         return instance;
     }
@@ -592,7 +749,10 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * @param id
      * @return
      */
-    public Object setDescription(RuleForm instance, String description) {
+    public RuleForm setDescription(RuleForm instance, String description) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkUPDATE(instance, networkedModel);
         instance.setDescription(description);
@@ -605,6 +765,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * @return
      */
     public RuleForm setName(RuleForm instance, String name) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkUPDATE(instance, networkedModel);
         instance.setName(name);
@@ -621,6 +784,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm setSingularChild(RuleForm instance,
                                      NetworkAuthorization<RuleForm> auth,
                                      RuleForm child) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
         checkREAD(child, networkedModel);
@@ -635,16 +801,17 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Set the singular xd child of the instance
      * 
      * @param instance
-     * @param facet
      * @param auth
      * @param child
      * @return
      */
     public RuleForm setSingularChild(RuleForm instance,
-                                     NetworkAuthorization<RuleForm> facet,
                                      XDomainNetworkAuthorization<?, ?> auth,
                                      @SuppressWarnings("rawtypes") ExistentialRuleform child) {
-        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
+        if (instance == null) {
+            return null;
+        }
+        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkUPDATE(auth, networkedModel);
         checkREAD(child, model.getUnknownNetworkedModel(child));
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -665,8 +832,11 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                              (Relationship) child);
         } else {
             throw new IllegalArgumentException(String.format("Invalid XdAuth %s -> %s",
-                                                             facet.getClassification(),
-                                                             childAuth.getClassification()));
+                                                             instance.getClass()
+                                                                     .getSimpleName(),
+                                                             childAuth.getClassification()
+                                                                      .getClass()
+                                                                      .getSimpleName()));
         }
         return instance;
     }

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -26,10 +26,11 @@ import static com.chiralbehaviors.CoRE.phantasm.model.PhantasmTraversal.resolveT
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -74,6 +75,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm addChild(RuleForm instance,
                              NetworkAuthorization<RuleForm> auth,
                              RuleForm child) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
         checkREAD(child, networkedModel);
@@ -94,6 +98,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm addChildren(RuleForm instance,
                                 NetworkAuthorization<RuleForm> auth,
                                 List<RuleForm> children) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
         for (RuleForm child : children) {
@@ -115,152 +122,14 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      */
     public RuleForm apply(NetworkAuthorization<RuleForm> facet,
                           RuleForm instance) throws SecurityException {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
         checkAPPLY(facet, networkedModel);
         networkedModel.initialize(instance, facet, model.getCurrentPrincipal()
                                                         .getPrincipal());
         return instance;
-    }
-
-    /**
-     * Apply the facet to the instance
-     * 
-     * @param facet
-     * @param id
-     * 
-     * @return
-     * @throws SecurityException
-     */
-    public RuleForm apply(NetworkAuthorization<RuleForm> facet,
-                          String id) throws SecurityException {
-        UUID uuid = UUID.fromString(id);
-        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(uuid);
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        if (uuid == null) {
-            return null;
-        }
-        return apply(facet, instance);
-    }
-
-    public void checkFacetCREATE(NetworkAuthorization<RuleForm> facet,
-                                 NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 facet, model.getKernel()
-                                                             .getCREATE())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getCREATE()));
-        }
-    }
-
-    public void checkFacetREAD(NetworkAuthorization<RuleForm> facet,
-                               NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 facet, model.getKernel()
-                                                             .getREAD())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getREAD()));
-        }
-    }
-
-    public void checkREAD(AttributeAuthorization<RuleForm, Network> stateAuth,
-                          NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            stateAuth, model.getKernel()
-                                                            .getREAD())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getREAD()));
-        }
-    }
-
-    public void checkREAD(@SuppressWarnings("rawtypes") ExistentialRuleform child,
-                          NetworkedModel<?, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            child, model.getKernel()
-                                                        .getREAD())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getREAD()));
-        }
-    }
-
-    public void checkREAD(NetworkAuthorization<RuleForm> auth,
-                          NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 auth, model.getKernel()
-                                                            .getREAD())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getREAD()));
-        }
-    }
-
-    public void checkREAD(XDomainNetworkAuthorization<?, ?> auth,
-                          NetworkedModel<?, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            auth, model.getKernel()
-                                                       .getREAD())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getREAD()));
-        }
-    }
-
-    public void checkUPDATE(@SuppressWarnings("rawtypes") ExistentialRuleform child,
-                            NetworkedModel<?, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            child, model.getKernel()
-                                                        .getUPDATE())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getUPDATE()));
-        }
-    }
-
-    public void checkUPDATE(NetworkAuthorization<RuleForm> auth,
-                            NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            auth, model.getKernel()
-                                                       .getUPDATE())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getUPDATE()));
-        }
-    }
-
-    public void checkUPDATE(XDomainNetworkAuthorization<?, ?> auth,
-                            NetworkedModel<?, ?, ?, ?> networkedModel) {
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            auth, model.getKernel()
-                                                       .getUPDATE())) {
-            throw new SecurityException(String.format("%s does not have %s capability",
-                                                      model.getCurrentPrincipal(),
-                                                      model.getKernel()
-                                                           .getUPDATE()));
-        }
     }
 
     /**
@@ -312,6 +181,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      */
     public Object getAttributeValue(RuleForm instance,
                                     AttributeAuthorization<RuleForm, Network> stateAuth) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(stateAuth.getNetworkAuthorization()
                                                                                             .getClassification());
         checkREAD(stateAuth, networkedModel);
@@ -341,6 +213,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      */
     public List<RuleForm> getChildren(RuleForm instance,
                                       NetworkAuthorization<RuleForm> auth) {
+        if (instance == null) {
+            return Collections.emptyList();
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkREAD(auth, networkedModel);
         return networkedModel.getChildren(instance, auth.getChildRelationship())
@@ -365,6 +240,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public List<?> getChildren(RuleForm instance,
                                NetworkAuthorization<RuleForm> facet,
                                XDomainNetworkAuthorization<?, ?> auth) {
+        if (instance == null) {
+            return Collections.emptyList();
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
         checkREAD(auth, networkedModel);
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -409,6 +287,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      */
     public List<RuleForm> getImmediateChildren(RuleForm instance,
                                                NetworkAuthorization<RuleForm> auth) {
+        if (instance == null) {
+            return Collections.emptyList();
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkREAD(auth, networkedModel);
         return networkedModel.getImmediateChildren(instance,
@@ -423,31 +304,12 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     }
 
     /**
-     * Answer the instance associated with the string uuid
-     * 
-     * @param id
-     * @param facet
-     * @return
-     */
-    public RuleForm getInstance(String id,
-                                NetworkAuthorization<RuleForm> facet) {
-
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        checkFacetREAD(facet, networkedModel);
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        checkREAD(instance, networkedModel);
-        return instance;
-
-    }
-
-    /**
      * Answer the list of instances of this facet.
      * 
      * @param facet
      * @return
      */
     public List<RuleForm> getInstances(NetworkAuthorization<RuleForm> facet) {
-
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
         checkFacetREAD(facet, networkedModel);
         return networkedModel.getChildren(facet.getClassification(),
@@ -471,6 +333,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      */
     public RuleForm getSingularChild(RuleForm instance,
                                      NetworkAuthorization<RuleForm> auth) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkREAD(auth, networkedModel);
         RuleForm child = networkedModel.getImmediateChild(instance,
@@ -490,6 +355,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public Object getSingularChild(RuleForm instance,
                                    NetworkAuthorization<RuleForm> facet,
                                    XDomainNetworkAuthorization<?, ?> auth) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
         checkREAD(auth, networkedModel);
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -520,6 +388,34 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return child;
     }
 
+    @SuppressWarnings("rawtypes")
+    public List<ExistentialRuleform> lookup(NetworkAuthorization auth,
+                                            List<String> ids) {
+        NetworkedModel<?, ?, ?, ?> networkedModel = model.getUnknownNetworkedModel(auth.getClassification());
+        return ids.stream()
+                  .map(id -> networkedModel.find(UUID.fromString(id)))
+                  .filter(rf -> rf != null)
+                  .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                                       .getPrincipal(),
+                                                                  child,
+                                                                  model.getKernel()
+                                                                       .getREAD()))
+                  .collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("rawtypes")
+    public ExistentialRuleform lookup(NetworkAuthorization auth, String id) {
+        NetworkedModel<?, ?, ?, ?> networkedModel = model.getUnknownNetworkedModel(auth.getClassification());
+        return Optional.of(networkedModel.find(UUID.fromString(id)))
+                       .filter(rf -> rf != null)
+                       .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                                            .getPrincipal(),
+                                                                       child,
+                                                                       model.getKernel()
+                                                                            .getREAD()))
+                       .get();
+    }
+
     /**
      * Remove the facet from the instance
      * 
@@ -531,31 +427,14 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm remove(NetworkAuthorization<RuleForm> facet,
                            RuleForm instance,
                            boolean deleteAttributes) throws SecurityException {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
         checkREMOVE(facet, networkedModel);
         networkedModel.initialize(instance, facet, model.getCurrentPrincipal()
                                                         .getPrincipal());
         return instance;
-    }
-
-    /**
-     * Remove the facet from the instance
-     * 
-     * @param facet
-     * @param instance
-     * @return
-     * @throws SecurityException
-     */
-    public RuleForm remove(NetworkAuthorization<RuleForm> facet, String id,
-                           boolean deleteAttributes) throws SecurityException {
-        UUID uuid = UUID.fromString(id);
-        NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(uuid);
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        return remove(facet, instance, deleteAttributes);
     }
 
     /**
@@ -568,6 +447,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm removeChild(RuleForm instance,
                                 NetworkAuthorization<RuleForm> auth,
                                 RuleForm child) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
         NetworkRuleform<RuleForm> link = networkedModel.getImmediateLink(instance,
@@ -590,6 +472,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm removeImmediateChildren(RuleForm instance,
                                             NetworkAuthorization<RuleForm> auth,
                                             List<RuleForm> children) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
         for (RuleForm child : children) {
@@ -604,66 +489,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
-    /**
-     * @param facet
-     * @param id
-     * @param auth
-     * @param value
-     * @return
-     */
-    public RuleForm setAttributeValue(NetworkAuthorization<RuleForm> facet,
-                                      String id,
-                                      AttributeAuthorization<RuleForm, Network> auth,
-                                      List<Object> value) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        return setAttributeValue(instance, auth, value);
-    }
-
-    /**
-     * @param facet
-     * @param id
-     * @param auth
-     * @param value
-     * @return
-     */
-    public RuleForm setAttributeValue(NetworkAuthorization<RuleForm> facet,
-                                      String id,
-                                      AttributeAuthorization<RuleForm, Network> auth,
-                                      Map<String, Object> value) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        return setAttributeValue(instance, auth, value);
-    }
-
-    /**
-     * @param facet
-     * @param id
-     * @param auth
-     * @param value
-     * @return
-     */
-    public RuleForm setAttributeValue(NetworkAuthorization<RuleForm> facet,
-                                      String id,
-                                      AttributeAuthorization<RuleForm, Network> auth,
-                                      Object value) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        return setAttributeValue(instance, auth, value);
-    }
-
     public RuleForm setAttributeValue(RuleForm instance,
                                       AttributeAuthorization<RuleForm, Network> stateAuth,
                                       List<Object> value) {
@@ -680,33 +505,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                       AttributeAuthorization<RuleForm, Network> stateAuth,
                                       Object value) {
         return instance;
-    }
-
-    /**
-     * Set the immediate children of the instance to be the list of supplied
-     * children. No inferred links will be explicitly added or deleted.
-     * 
-     * @param facet
-     * @param id
-     * @param auth
-     * @param childrenIds
-     * 
-     * @return
-     */
-    public RuleForm setChildren(NetworkAuthorization<RuleForm> facet, String id,
-                                NetworkAuthorization<RuleForm> auth,
-                                List<String> childrenIds) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        List<RuleForm> children = new ArrayList<>();
-        for (String childId : childrenIds) {
-            children.add(networkedModel.find(UUID.fromString(childId)));
-        }
-        return setChildren(instance, auth, children);
     }
 
     /**
@@ -720,6 +518,9 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     public RuleForm setChildren(RuleForm instance,
                                 NetworkAuthorization<RuleForm> auth,
                                 List<RuleForm> children) {
+        if (instance == null) {
+            return null;
+        }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
         checkUPDATE(auth, networkedModel);
 
@@ -787,92 +588,27 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     }
 
     /**
-     * Set the xd children of the instance.
-     * 
-     * @param id
-     * @param auth
-     * @param childrenIds
-     * @return
-     */
-    public RuleForm setChildren(String id, NetworkAuthorization<RuleForm> facet,
-                                XDomainNetworkAuthorization<?, ?> auth,
-                                List<String> childrenIds) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
-        @SuppressWarnings("rawtypes")
-        List<ExistentialRuleform> children = new ArrayList<>();
-        NetworkAuthorization<?> child = auth.isForward() ? resolveTo(auth,
-                                                                     model)
-                                                         : resolveFrom(auth,
-                                                                       model);
-        for (String childId : childrenIds) {
-            children.add(lookup(child, childId));
-        }
-        return setChildren(instance, facet, auth, children);
-    }
-
-    /**
-     * @param facet
-     * @param id
      * @param description
+     * @param id
      * @return
      */
-    public Object setDescription(NetworkAuthorization<RuleForm> facet,
-                                 String id, String description) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
+    public Object setDescription(RuleForm instance, String description) {
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkUPDATE(instance, networkedModel);
         instance.setDescription(description);
         return instance;
     }
 
     /**
-     * @param facet
-     * @param id
      * @param name
+     * @param id
      * @return
      */
-    public RuleForm setName(NetworkAuthorization<RuleForm> facet, String id,
-                            String name) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(instance, networkedModel);
+    public RuleForm setName(RuleForm instance, String name) {
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         checkUPDATE(instance, networkedModel);
         instance.setName(name);
         return instance;
-    }
-
-    /**
-     * @param facet
-     * @param auth
-     * @param argument
-     * @param facet
-     * @param argument2
-     * @return
-     */
-    public RuleForm setSingularChild(NetworkAuthorization<RuleForm> facet,
-                                     String id,
-                                     NetworkAuthorization<RuleForm> auth,
-                                     String childId) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkREAD(auth, networkedModel);
-        RuleForm child = lookup(auth, childId);
-        return setSingularChild(instance, auth, child);
     }
 
     /**
@@ -935,25 +671,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
-    public RuleForm setSingularChild(String id,
-                                     NetworkAuthorization<RuleForm> facet,
-                                     XDomainNetworkAuthorization<?, ?> auth,
-                                     String childId) {
-        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        RuleForm instance = networkedModel.find(UUID.fromString(id));
-        if (instance == null) {
-            return null;
-        }
-        checkFacetREAD(facet, networkedModel);
-        NetworkAuthorization<?> child = auth.isForward() ? resolveTo(auth,
-                                                                     model)
-                                                         : resolveFrom(auth,
-                                                                       model);
-        return setSingularChild(instance, facet, auth,
-                                model.getUnknownNetworkedModel(child.getClassification())
-                                     .find(UUID.fromString(childId)));
-    }
-
     private void checkAPPLY(NetworkAuthorization<RuleForm> facet,
                             NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
         if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
@@ -967,6 +684,84 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
     }
 
+    private void checkFacetCREATE(NetworkAuthorization<RuleForm> facet,
+                                  NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
+                                                      .getPrincipal(),
+                                                 facet, model.getKernel()
+                                                             .getCREATE())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getCREATE()));
+        }
+    }
+
+    private void checkFacetREAD(NetworkAuthorization<RuleForm> facet,
+                                NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
+                                                      .getPrincipal(),
+                                                 facet, model.getKernel()
+                                                             .getREAD())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getREAD()));
+        }
+    }
+
+    private void checkREAD(AttributeAuthorization<RuleForm, Network> stateAuth,
+                           NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                 .getPrincipal(),
+                                            stateAuth, model.getKernel()
+                                                            .getREAD())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getREAD()));
+        }
+    }
+
+    private void checkREAD(@SuppressWarnings("rawtypes") ExistentialRuleform child,
+                           NetworkedModel<?, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                 .getPrincipal(),
+                                            child, model.getKernel()
+                                                        .getREAD())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getREAD()));
+        }
+    }
+
+    private void checkREAD(NetworkAuthorization<RuleForm> auth,
+                           NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
+                                                      .getPrincipal(),
+                                                 auth, model.getKernel()
+                                                            .getREAD())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getREAD()));
+        }
+    }
+
+    private void checkREAD(XDomainNetworkAuthorization<?, ?> auth,
+                           NetworkedModel<?, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                 .getPrincipal(),
+                                            auth, model.getKernel()
+                                                       .getREAD())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getREAD()));
+        }
+    }
+
     private void checkREMOVE(NetworkAuthorization<RuleForm> facet,
                              NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
         if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
@@ -977,6 +772,45 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                                       model.getCurrentPrincipal(),
                                                       model.getKernel()
                                                            .getREMOVE()));
+        }
+    }
+
+    private void checkUPDATE(@SuppressWarnings("rawtypes") ExistentialRuleform child,
+                             NetworkedModel<?, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                 .getPrincipal(),
+                                            child, model.getKernel()
+                                                        .getUPDATE())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getUPDATE()));
+        }
+    }
+
+    private void checkUPDATE(NetworkAuthorization<RuleForm> auth,
+                             NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                 .getPrincipal(),
+                                            auth, model.getKernel()
+                                                       .getUPDATE())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getUPDATE()));
+        }
+    }
+
+    private void checkUPDATE(XDomainNetworkAuthorization<?, ?> auth,
+                             NetworkedModel<?, ?, ?, ?> networkedModel) {
+        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                 .getPrincipal(),
+                                            auth, model.getKernel()
+                                                       .getUPDATE())) {
+            throw new SecurityException(String.format("%s does not have %s capability",
+                                                      model.getCurrentPrincipal(),
+                                                      model.getKernel()
+                                                           .getUPDATE()));
         }
     }
 
@@ -1035,28 +869,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             map.put(value.getKey(), value);
         }
         return map;
-    }
-
-    @SuppressWarnings("unchecked")
-    private RuleForm lookup(@SuppressWarnings("rawtypes") NetworkAuthorization auth,
-                            String id) {
-        UUID uuid = UUID.fromString(id);
-        if (auth.getClassification() instanceof Agency) {
-            return (RuleForm) model.getAgencyModel()
-                                   .find(uuid);
-        } else if (auth.getClassification() instanceof Location) {
-            return (RuleForm) model.getLocationModel()
-                                   .find(uuid);
-        } else if (auth.getClassification() instanceof Product) {
-            return (RuleForm) model.getProductModel()
-                                   .find(uuid);
-        } else if (auth.getClassification() instanceof Relationship) {
-            return (RuleForm) model.getRelationshipModel()
-                                   .find(uuid);
-        } else {
-            throw new IllegalArgumentException(String.format("Invalid XdAuth target: %s",
-                                                             auth.getClassification()));
-        }
     }
 
     private AttributeValue<RuleForm> newAttributeValue(RuleForm instance,

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmTraversal.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmTraversal.java
@@ -75,10 +75,13 @@ public class PhantasmTraversal<RuleForm extends ExistentialRuleform<RuleForm, Ne
          *            - the normalized field name
          * @param child
          *            - the child facet
+         * @param singularFieldName
+         *            - the singular form of the field name
          */
         void visitChildren(NetworkAuthorization<RuleForm> auth,
                            String fieldName,
-                           NetworkAuthorization<RuleForm> child);
+                           NetworkAuthorization<RuleForm> child,
+                           String singularFieldName);
 
         /**
          * Visit the multiple child xd authorization
@@ -89,9 +92,12 @@ public class PhantasmTraversal<RuleForm extends ExistentialRuleform<RuleForm, Ne
          *            - the normalized field name
          * @param child
          *            - the child facet
+         * @param singularFieldName
+         *            TODO
          */
         void visitChildren(XDomainNetworkAuthorization<?, ?> auth,
-                           String fieldName, NetworkAuthorization<?> child);
+                           String fieldName, NetworkAuthorization<?> child,
+                           String singularFieldName);
 
         /**
          * Visit the singular child network authorization
@@ -238,7 +244,8 @@ public class PhantasmTraversal<RuleForm extends ExistentialRuleform<RuleForm, Ne
                                                            networkedModel);
             String fieldName = toFieldName(auth.getName());
             if (auth.getCardinality() == Cardinality.N) {
-                visitor.visitChildren(auth, English.plural(fieldName), child);
+                visitor.visitChildren(auth, English.plural(fieldName), child,
+                                      fieldName);
             } else {
                 visitor.visitSingular(auth, fieldName, child);
             }
@@ -286,8 +293,8 @@ public class PhantasmTraversal<RuleForm extends ExistentialRuleform<RuleForm, Ne
                                 PhantasmVisitor<RuleForm, Network> visitor) {
         String fieldName = toFieldName(auth.getName());
         if (auth.getCardinality() == Cardinality.N) {
-            fieldName = English.plural(fieldName);
-            visitor.visitChildren(auth, fieldName, child);
+            visitor.visitChildren(auth, English.plural(fieldName), child,
+                                  fieldName);
         } else {
             visitor.visitSingular(auth, fieldName, child);
         }

--- a/animations/src/test/resources/jpa.properties
+++ b/animations/src/test/resources/jpa.properties
@@ -6,8 +6,9 @@ dba.driver: org.postgresql.Driver
 dba.url: jdbc:postgresql://${db.server}:${db.port}/${db.database}
 dba.username: ${db.login}
 dba.password: ${db.password}
-#hibernate.cache.use_second_level_cache=true
+hibernate.cache.use_second_level_cache=true
 #hibernate.cache.use_query_cache=true
-#hibernate.cache.provider_class = org.hibernate.cache.EhCacheProvider
+hibernate.cache.provider_class = org.hibernate.cache.OSCacheProvider
 #hibernate.cache.use_structured_entries = true
 #hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+

--- a/animations/src/test/resources/jpa.properties
+++ b/animations/src/test/resources/jpa.properties
@@ -8,7 +8,7 @@ dba.username: ${db.login}
 dba.password: ${db.password}
 hibernate.cache.use_second_level_cache=true
 #hibernate.cache.use_query_cache=true
-hibernate.cache.provider_class = org.hibernate.cache.OSCacheProvider
+#hibernate.cache.provider_class = org.hibernate.cache.OSCacheProvider
 #hibernate.cache.use_structured_entries = true
 #hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
 

--- a/animations/src/test/resources/logback-test.xml
+++ b/animations/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
         <level value="INFO" />
     </logger>
     <logger name="org.hibernate">
-        <level value="INFO" />
+        <level value="ERROR" />
     </logger>
     <logger name="org.hibernate.SQL">
         <level value="ERROR" />
@@ -19,10 +19,10 @@
         <level value="ERROR" />
     </logger>
     <logger name="org.hibernate.cache">
-        <level value="INFO" />
+        <level value="ERROR" />
     </logger>
     <root>
-        <level value="INFO" />
+        <level value="ERROR" />
         <appender-ref ref="C" />
     </root>
 

--- a/animations/src/test/resources/logback-test.xml
+++ b/animations/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
         <level value="INFO" />
     </logger>
     <logger name="org.hibernate">
-        <level value="ERROR" />
+        <level value="INFO" />
     </logger>
     <logger name="org.hibernate.SQL">
         <level value="ERROR" />
@@ -19,7 +19,7 @@
         <level value="ERROR" />
     </logger>
     <logger name="org.hibernate.cache">
-        <level value="ERROR" />
+        <level value="INFO" />
     </logger>
     <root>
         <level value="INFO" />

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -66,25 +66,39 @@ import graphql.schema.GraphQLTypeReference;
 public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, Network extends NetworkRuleform<RuleForm>>
         implements PhantasmTraversal.PhantasmVisitor<RuleForm, Network> {
 
-    private static final String SET_TEMPLATE          = "set%s";
     private static final String APPLY_TEMPLATE        = "Apply%s";
-    private static final String CREATE_TEMPLATE       = "Create%s";
     private static final String AT_RULEFORM           = "@ruleform";
+    private static final String CREATE_TEMPLATE       = "Create%s";
     private static final String DESCRIPTION           = "description";
     private static final String ID                    = "id";
     private static final String INSTANCES_OF_TEMPLATE = "InstancesOf%s";
     private static final String NAME                  = "name";
     private static final String REMOVE_TEMPLATE       = "Remove%s";
+    private static final String SET_DESCRIPTION;
+    private static final String SET_NAME;
+    private static final String SET_TEMPLATE          = "set%s";
     private static final String STATE                 = "state";
     private static final String UPDATE_TEMPLATE       = "Update%s";
     private static final String UPDATE_TYPE_TEMPLATE  = "%sUpdate";
 
+    static {
+        SET_NAME = String.format(SET_TEMPLATE, capitalized(NAME));
+        SET_DESCRIPTION = String.format(SET_TEMPLATE, capitalized(DESCRIPTION));
+    }
+
+    private static String capitalized(String field) {
+        char[] chars = field.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
+    }
+
     private final NetworkAuthorization<RuleForm>                                                          facet;
     private final Model                                                                                   model;
-    private graphql.schema.GraphQLInputObjectType.Builder                                                 updateTypeBuilder;
     private final Set<NetworkAuthorization<?>>                                                            references     = new HashSet<>();
     private Builder                                                                                       typeBuilder;
     private final Map<String, BiFunction<PhantasmCRUD<RuleForm, Network>, Map<String, Object>, RuleForm>> updateTemplate = new HashMap<>();
+
+    private graphql.schema.GraphQLInputObjectType.Builder updateTypeBuilder;
 
     public FacetType(NetworkAuthorization<RuleForm> facet, Model model) {
         this.model = model;
@@ -303,12 +317,6 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                    .build();
     }
 
-    private String capitalized(String field) {
-        char[] chars = field.toCharArray();
-        chars[0] = Character.toUpperCase(chars[0]);
-        return new String(chars);
-    }
-
     @SuppressWarnings("unchecked")
     private void buildRuleformAttributes() {
         typeBuilder.field(newFieldDefinition().type(GraphQLString)
@@ -329,29 +337,24 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .description(String.format("the id of the updated %s",
                                                                                 facet.getName()))
                                                      .build());
-
-        String setName = String.format(SET_TEMPLATE, capitalized(NAME));
         updateTypeBuilder.field(newInputObjectField().type(GraphQLString)
-                                                     .name(setName)
+                                                     .name(SET_NAME)
                                                      .description(String.format("the name to update on %s",
                                                                                 facet.getName()))
                                                      .build());
-        updateTemplate.put(setName,
+        updateTemplate.put(SET_NAME,
                            (crud,
                             update) -> crud.setName((RuleForm) update.get(AT_RULEFORM),
-                                                    (String) update.get(setName)));
-
-        String setDescription = String.format(SET_TEMPLATE,
-                                              capitalized(DESCRIPTION));
+                                                    (String) update.get(SET_NAME)));
         updateTypeBuilder.field(newInputObjectField().type(GraphQLString)
-                                                     .name(setDescription)
+                                                     .name(SET_DESCRIPTION)
                                                      .description(String.format("the description to update on %s",
                                                                                 facet.getName()))
                                                      .build());
-        updateTemplate.put(setDescription,
+        updateTemplate.put(SET_DESCRIPTION,
                            (crud,
                             update) -> crud.setName((RuleForm) update.get(AT_RULEFORM),
-                                                    (String) update.get(setDescription)));
+                                                    (String) update.get(SET_DESCRIPTION)));
     }
 
     @SuppressWarnings("unchecked")
@@ -368,9 +371,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                        PhantasmCRUD<RuleForm, Network> crud = ctx(env);
                                        RuleForm ruleform = crud.createInstance(facet,
                                                                                (String) updateState.get(String.format(SET_TEMPLATE,
-                                                                                                                      capitalized(NAME))),
+                                                                                                                      SET_NAME)),
                                                                                (String) updateState.get(String.format(SET_TEMPLATE,
-                                                                                                                      capitalized(DESCRIPTION))));
+                                                                                                                      SET_DESCRIPTION)));
                                        return ruleform == null ? null
                                                                : update(ruleform,
                                                                         updateState,

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/resources/GraphQlResource.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/resources/GraphQlResource.java
@@ -176,9 +176,11 @@ public class GraphQlResource extends TransactionalResource {
             UUID uuid = Workspace.uuidOf(workspace);
             GraphQLSchema schema = cache.get(uuid);
             if (schema == null) {
-                WorkspaceScope scoped = model.getWorkspaceModel()
-                                             .getScoped(uuid);
-                if (scoped == null) {
+                WorkspaceScope scoped;
+                try {
+                    scoped = model.getWorkspaceModel()
+                                  .getScoped(uuid);
+                } catch (IllegalArgumentException e) {
                     result.put("errors",
                                String.format("Workspace %s does not exist",
                                              workspace));

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>opensymphony</groupId>
+                <artifactId>oscache</artifactId>
+                <version>2.4.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.chiralbehaviors.CoRE</groupId>
                 <artifactId>phantasm-at-rest</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
@@ -352,10 +357,15 @@
                 <artifactId>graphql-java</artifactId>
                 <version>1.2</version>
             </dependency>
+            <dependency>
+                <groupId>javax.jms</groupId>
+                <artifactId>jms</artifactId>
+                <version>1.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
-    <repositories> 
+    <repositories>
         <repository>
             <id>chiralbehaviors-snapshots</id>
             <url>http://repository-chiralbehaviors.forge.cloudbees.com/snapshot/</url>
@@ -369,6 +379,11 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>repository.jboss.org-public</id>
+            <name>JBoss.org Maven repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Add remaining mutations for updating/creating facet state.  Simplify PhantasmCRUD by removing overloads for string ids.  Simplify FacetType generation.  Create{Phantasm} now takes {Phantasm}Update state as an argument.

Made the network inference a little quicker.  Looks like I still have work to make the inference query stabilize faster.