### PR TITLE
Phantasm attributes

### DIFF
--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -81,10 +81,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkUPDATE(facet, networkedModel)) {
-            return instance;
-        }
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
 
@@ -103,10 +101,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkUPDATE(facet, networkedModel)) {
-            return instance;
-        }
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -156,10 +152,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkUPDATE(facet, networkedModel)) {
-            return instance;
-        }
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         children.stream()
@@ -181,10 +175,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkUPDATE(facet, networkedModel)) {
-            return instance;
-        }
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -308,7 +300,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Answer the attribute value of the instance
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param stateAuth
      * 
@@ -322,13 +313,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(stateAuth.getNetworkAuthorization()
                                                                                             .getClassification());
-        if (!checkREAD(facet, networkedModel)) {
-            return instance;
-        }
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            stateAuth, model.getKernel()
-                                                            .getREAD())) {
+        if (!checkREAD(facet, networkedModel)
+            || checkREAD(stateAuth, networkedModel)) {
             return null;
         }
         Attribute authorizedAttribute = stateAuth.getAuthorizedAttribute();
@@ -348,6 +334,14 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return value;
     }
 
+    private boolean checkREAD(AttributeAuthorization<RuleForm, Network> stateAuth,
+                              NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        return !networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                    .getPrincipal(),
+                                               stateAuth, model.getKernel()
+                                                               .getREAD());
+    }
+
     /**
      * Answer the inferred and immediate network children of the instance
      * 
@@ -364,10 +358,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return Collections.emptyList();
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkREAD(facet, networkedModel)) {
-            return Collections.emptyList();
-        }
-        if (!checkREAD(auth, networkedModel)) {
+        if (!checkREAD(facet, networkedModel)
+            || !checkREAD(auth, networkedModel)) {
             return Collections.emptyList();
         }
         return networkedModel.getChildren(instance, auth.getChildRelationship())
@@ -397,10 +389,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return Collections.emptyList();
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkREAD(facet, networkedModel)) {
-            return Collections.emptyList();
-        }
-        if (!checkREAD(auth, networkedModel)) {
+        if (!checkREAD(facet, networkedModel)
+            || !checkREAD(auth, networkedModel)) {
             return Collections.emptyList();
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -455,10 +445,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return Collections.emptyList();
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkREAD(facet, networkedModel)) {
-            return Collections.emptyList();
-        }
-        if (!checkREAD(auth, networkedModel)) {
+        if (!checkREAD(facet, networkedModel)
+            || !checkREAD(auth, networkedModel)) {
             return Collections.emptyList();
         }
         return networkedModel.getImmediateChildren(instance,
@@ -490,12 +478,17 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                           facet.getClassifier()
                                                .getInverse())
                              .stream()
-                             .filter(instance -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                                     .getPrincipal(),
-                                                                                instance,
-                                                                                model.getKernel()
-                                                                                     .getREAD()))
+                             .filter(instance -> checkREAD(networkedModel,
+                                                           instance))
                              .collect(Collectors.toList());
+    }
+
+    private boolean checkREAD(NetworkedModel<RuleForm, ?, ?, ?> networkedModel,
+                              RuleForm instance) {
+        return networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                   .getPrincipal(),
+                                              instance, model.getKernel()
+                                                             .getREAD());
     }
 
     /**
@@ -514,10 +507,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkREAD(facet, networkedModel)) {
-            return null;
-        }
-        if (!checkREAD(auth, networkedModel)) {
+        if (!checkREAD(facet, networkedModel)
+            || !checkREAD(auth, networkedModel)) {
             return null;
         }
         RuleForm child = networkedModel.getImmediateChild(instance,
@@ -540,10 +531,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkREAD(facet, networkedModel)) {
-            return Collections.emptyList();
-        }
-        if (!checkREAD(auth, networkedModel)) {
+        if (!checkREAD(facet, networkedModel)
+            || !checkREAD(auth, networkedModel)) {
             return null;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -592,6 +581,19 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                   .collect(Collectors.toList());
     }
 
+    @SuppressWarnings("rawtypes")
+    public ExistentialRuleform lookup(NetworkAuthorization auth, String id) {
+        NetworkedModel<?, ?, ?, ?> networkedModel = model.getUnknownNetworkedModel(auth.getClassification());
+        return Optional.of(networkedModel.find(UUID.fromString(id)))
+                       .filter(rf -> rf != null)
+                       .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                                            .getPrincipal(),
+                                                                       child,
+                                                                       model.getKernel()
+                                                                            .getREAD()))
+                       .get();
+    }
+
     public List<RuleForm> lookupRuleForm(NetworkAuthorization<RuleForm> auth,
                                          List<String> ids) {
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
@@ -604,19 +606,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                                                   model.getKernel()
                                                                        .getREAD()))
                   .collect(Collectors.toList());
-    }
-
-    @SuppressWarnings("rawtypes")
-    public ExistentialRuleform lookup(NetworkAuthorization auth, String id) {
-        NetworkedModel<?, ?, ?, ?> networkedModel = model.getUnknownNetworkedModel(auth.getClassification());
-        return Optional.of(networkedModel.find(UUID.fromString(id)))
-                       .filter(rf -> rf != null)
-                       .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                            .getPrincipal(),
-                                                                       child,
-                                                                       model.getKernel()
-                                                                            .getREAD()))
-                       .get();
     }
 
     /**
@@ -648,18 +637,22 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     /**
      * Remove a child from the instance
      * 
+     * @param facet
+     *            TODO
      * @param instance
      * @param auth
      * @param child
      */
-    public RuleForm removeChild(RuleForm instance,
+    public RuleForm removeChild(NetworkAuthorization<RuleForm> facet,
+                                RuleForm instance,
                                 NetworkAuthorization<RuleForm> auth,
                                 RuleForm child) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkRuleform<RuleForm> link = networkedModel.getImmediateLink(instance,
@@ -672,14 +665,16 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
-    public RuleForm removeChild(RuleForm instance,
+    public RuleForm removeChild(NetworkAuthorization<RuleForm> facet,
+                                RuleForm instance,
                                 XDomainNetworkAuthorization<?, ?> auth,
                                 @SuppressWarnings("rawtypes") ExistentialRuleform child) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -712,18 +707,22 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     /**
      * Remove the immediate child links from the instance
      * 
+     * @param facet
+     *            TODO
      * @param instance
      * @param auth
      * @param children
      */
-    public RuleForm removeChildren(RuleForm instance,
+    public RuleForm removeChildren(NetworkAuthorization<RuleForm> facet,
+                                   RuleForm instance,
                                    NetworkAuthorization<RuleForm> auth,
                                    List<RuleForm> children) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         for (RuleForm child : children) {
@@ -738,14 +737,16 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
-    public RuleForm removeChildren(RuleForm instance,
+    public RuleForm removeChildren(NetworkAuthorization<RuleForm> facet,
+                                   RuleForm instance,
                                    XDomainNetworkAuthorization<?, ?> auth,
                                    @SuppressWarnings("rawtypes") List<ExistentialRuleform> children) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -777,15 +778,31 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
-    public RuleForm setAttributeValue(RuleForm instance,
+    public RuleForm setAttributeValue(NetworkAuthorization<RuleForm> facet,
+                                      RuleForm instance,
                                       AttributeAuthorization<RuleForm, Network> stateAuth,
                                       List<Object> value) {
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(stateAuth, networkedModel)) {
+            return instance;
+        }
+        setAttributeArray(instance, stateAuth.getAuthorizedAttribute(),
+                          value.toArray(), networkedModel);
         return instance;
     }
 
-    public RuleForm setAttributeValue(RuleForm instance,
+    public RuleForm setAttributeValue(NetworkAuthorization<RuleForm> facet,
+                                      RuleForm instance,
                                       AttributeAuthorization<RuleForm, Network> stateAuth,
                                       Map<String, Object> value) {
+        NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(stateAuth, networkedModel)) {
+            return instance;
+        }
+        setAttributeMap(instance, stateAuth.getAuthorizedAttribute(), value,
+                        networkedModel);
         return instance;
     }
 
@@ -798,35 +815,44 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(stateAuth.getNetworkAuthorization()
                                                                                             .getClassification());
-        if (!checkUPDATE(facet, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || checkUPDATE(stateAuth, networkedModel)) {
             return instance;
         }
-        if (!networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                 .getPrincipal(),
-                                            stateAuth, model.getKernel()
-                                                            .getUPDATE())) {
-            return instance;
-        }
-        Attribute authorizedAttribute = stateAuth.getAuthorizedAttribute();
+        networkedModel.getAttributeValue(instance,
+                                         stateAuth.getAuthorizedAttribute())
+                      .setValue(value);
         return instance;
+    }
+
+    private boolean checkUPDATE(AttributeAuthorization<RuleForm, Network> stateAuth,
+                                NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        return !networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                    .getPrincipal(),
+                                               stateAuth, model.getKernel()
+                                                               .getUPDATE());
     }
 
     /**
      * Set the immediate children of the instance to be the list of supplied
      * children. No inferred links will be explicitly added or deleted.
      * 
+     * @param facet
+     *            TODO
      * @param instance
      * @param auth
      * @param children
      */
-    public RuleForm setChildren(RuleForm instance,
+    public RuleForm setChildren(NetworkAuthorization<RuleForm> facet,
+                                RuleForm instance,
                                 NetworkAuthorization<RuleForm> auth,
                                 List<RuleForm> children) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
 
@@ -848,19 +874,23 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     /**
      * Set the xd children of the instance.
      * 
+     * @param facet
+     *            TODO
      * @param instance
      * @param auth
      * @param children
      */
     @SuppressWarnings({ "unchecked" })
-    public RuleForm setChildren(RuleForm instance,
+    public RuleForm setChildren(NetworkAuthorization<RuleForm> facet,
+                                RuleForm instance,
                                 XDomainNetworkAuthorization<?, ?> auth,
                                 List<?> children) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -935,18 +965,22 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     /**
      * Set the singular child of the instance.
      * 
+     * @param facet
+     *            TODO
      * @param instance
      * @param auth
      * @param child
      */
-    public RuleForm setSingularChild(RuleForm instance,
+    public RuleForm setSingularChild(NetworkAuthorization<RuleForm> facet,
+                                     RuleForm instance,
                                      NetworkAuthorization<RuleForm> auth,
                                      RuleForm child) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(auth.getClassification());
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         networkedModel.setImmediateChild(instance, model.getEntityManager()
@@ -959,19 +993,24 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     /**
      * Set the singular xd child of the instance
      * 
+     * @param facet
+     *            TODO
      * @param instance
      * @param auth
      * @param child
+     * 
      * @return
      */
-    public RuleForm setSingularChild(RuleForm instance,
+    public RuleForm setSingularChild(NetworkAuthorization<RuleForm> facet,
+                                     RuleForm instance,
                                      XDomainNetworkAuthorization<?, ?> auth,
                                      @SuppressWarnings("rawtypes") ExistentialRuleform child) {
         if (instance == null) {
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(instance);
-        if (!checkUPDATE(auth, networkedModel)) {
+        if (!checkUPDATE(facet, networkedModel)
+            || !checkUPDATE(auth, networkedModel)) {
             return instance;
         }
         NetworkAuthorization<?> childAuth = auth.isForward() ? resolveTo(auth,
@@ -1122,7 +1161,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return value;
     }
 
-    @SuppressWarnings("unused")
     private void setAttributeArray(RuleForm instance,
                                    Attribute authorizedAttribute,
                                    Object[] values,

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -334,14 +334,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return value;
     }
 
-    private boolean checkREAD(AttributeAuthorization<RuleForm, Network> stateAuth,
-                              NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        return !networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                    .getPrincipal(),
-                                               stateAuth, model.getKernel()
-                                                               .getREAD());
-    }
-
     /**
      * Answer the inferred and immediate network children of the instance
      * 
@@ -481,14 +473,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                              .filter(instance -> checkREAD(networkedModel,
                                                            instance))
                              .collect(Collectors.toList());
-    }
-
-    private boolean checkREAD(NetworkedModel<RuleForm, ?, ?, ?> networkedModel,
-                              RuleForm instance) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              instance, model.getKernel()
-                                                             .getREAD());
     }
 
     /**
@@ -823,14 +807,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
-    private boolean checkUPDATE(AttributeAuthorization<RuleForm, Network> stateAuth,
-                                NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        return !networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                    .getPrincipal(),
-                                               stateAuth, model.getKernel()
-                                                               .getUPDATE());
-    }
-
     /**
      * Set the immediate children of the instance to be the list of supplied
      * children. No inferred links will be explicitly added or deleted.
@@ -1038,6 +1014,14 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return instance;
     }
 
+    private boolean checkREAD(AttributeAuthorization<RuleForm, Network> stateAuth,
+                              NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        return networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                   .getPrincipal(),
+                                              stateAuth, model.getKernel()
+                                                              .getREAD());
+    }
+
     private boolean checkREAD(@SuppressWarnings("rawtypes") ExistentialRuleform child,
                               NetworkedModel<?, ?, ?, ?> networkedModel) {
         return networkedModel.checkCapability(model.getCurrentPrincipal()
@@ -1054,12 +1038,28 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                                               .getREAD());
     }
 
+    private boolean checkREAD(NetworkedModel<RuleForm, ?, ?, ?> networkedModel,
+                              RuleForm instance) {
+        return networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                   .getPrincipal(),
+                                              instance, model.getKernel()
+                                                             .getREAD());
+    }
+
     private boolean checkREAD(XDomainNetworkAuthorization<?, ?> auth,
                               NetworkedModel<?, ?, ?, ?> networkedModel) {
         return networkedModel.checkCapability(model.getCurrentPrincipal()
                                                    .getPrincipal(),
                                               auth, model.getKernel()
                                                          .getREAD());
+    }
+
+    private boolean checkUPDATE(AttributeAuthorization<RuleForm, Network> stateAuth,
+                                NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
+        return networkedModel.checkCapability(model.getCurrentPrincipal()
+                                                   .getPrincipal(),
+                                              stateAuth, model.getKernel()
+                                                              .getUPDATE());
     }
 
     private boolean checkUPDATE(@SuppressWarnings("rawtypes") ExistentialRuleform child,

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -638,7 +638,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Remove a child from the instance
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param auth
      * @param child
@@ -708,7 +707,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Remove the immediate child links from the instance
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param auth
      * @param children
@@ -838,7 +836,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * children. No inferred links will be explicitly added or deleted.
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param auth
      * @param children
@@ -875,7 +872,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Set the xd children of the instance.
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param auth
      * @param children
@@ -966,7 +962,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Set the singular child of the instance.
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param auth
      * @param child
@@ -994,7 +989,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      * Set the singular xd child of the instance
      * 
      * @param facet
-     *            TODO
      * @param instance
      * @param auth
      * @param child
@@ -1203,7 +1197,6 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
     }
 
-    @SuppressWarnings("unused")
     private void setAttributeMap(RuleForm instance,
                                  Attribute authorizedAttribute,
                                  Map<String, Object> values,

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -314,7 +314,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(stateAuth.getNetworkAuthorization()
                                                                                             .getClassification());
         if (!checkREAD(facet, networkedModel)
-            || checkREAD(stateAuth, networkedModel)) {
+            || !checkREAD(stateAuth, networkedModel)) {
             return null;
         }
         Attribute authorizedAttribute = stateAuth.getAuthorizedAttribute();
@@ -798,7 +798,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(stateAuth.getNetworkAuthorization()
                                                                                             .getClassification());
         if (!checkUPDATE(facet, networkedModel)
-            || checkUPDATE(stateAuth, networkedModel)) {
+            || !checkUPDATE(stateAuth, networkedModel)) {
             return instance;
         }
         networkedModel.getAttributeValue(instance,

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -801,8 +801,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             || !checkUPDATE(stateAuth, networkedModel)) {
             return instance;
         }
-        networkedModel.getAttributeValue(instance,
-                                         stateAuth.getAuthorizedAttribute())
+        networkedModel.getAttributeValue(instance, model.getEntityManager()
+                                                        .merge(stateAuth.getAuthorizedAttribute()))
                       .setValue(value);
         return instance;
     }
@@ -1162,6 +1162,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         AttributeValue<RuleForm>[] old = getValueArray(instance,
                                                        authorizedAttribute,
                                                        networkedModel);
+        authorizedAttribute = model.getEntityManager()
+                                   .merge(authorizedAttribute);
         if (values == null) {
             if (old != null) {
                 for (AttributeValue<RuleForm> value : old) {
@@ -1171,24 +1173,29 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             }
         } else if (old == null) {
             for (int i = 0; i < values.length; i++) {
-                setValue(instance, authorizedAttribute, i, null, values[i]);
+                setValue(instance, authorizedAttribute, i, null, values[i],
+                         networkedModel);
             }
         } else if (old.length == values.length) {
             for (int i = 0; i < values.length; i++) {
-                setValue(instance, authorizedAttribute, i, old[i], values[i]);
+                setValue(instance, authorizedAttribute, i, old[i], values[i],
+                         networkedModel);
             }
         } else if (old.length < values.length) {
             int i;
             for (i = 0; i < old.length; i++) {
-                setValue(instance, authorizedAttribute, i, old[i], values[i]);
+                setValue(instance, authorizedAttribute, i, old[i], values[i],
+                         networkedModel);
             }
             for (; i < values.length; i++) {
-                setValue(instance, authorizedAttribute, i, null, values[i]);
+                setValue(instance, authorizedAttribute, i, null, values[i],
+                         networkedModel);
             }
         } else if (old.length > values.length) {
             int i;
             for (i = 0; i < values.length; i++) {
-                setValue(instance, authorizedAttribute, i, old[i], values[i]);
+                setValue(instance, authorizedAttribute, i, old[i], values[i],
+                         networkedModel);
             }
             for (; i < old.length; i++) {
                 model.getEntityManager()
@@ -1212,6 +1219,8 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         for (AttributeValue<RuleForm> value : valueMap.values()) {
             maxSeq = Math.max(maxSeq, value.getSequenceNumber());
         }
+        authorizedAttribute = model.getEntityManager()
+                                   .merge(authorizedAttribute);
         for (Map.Entry<String, Object> entry : values.entrySet()) {
             AttributeValue<RuleForm> value = valueMap.get(entry.getKey());
             if (value == null) {
@@ -1226,9 +1235,11 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
     }
 
     private void setValue(RuleForm instance, Attribute attribute, int i,
-                          AttributeValue<RuleForm> existing, Object newValue) {
+                          AttributeValue<RuleForm> existing, Object newValue,
+                          NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
         if (existing == null) {
-            existing = newAttributeValue(null, attribute, i, null);
+            existing = newAttributeValue(instance, attribute, i,
+                                         networkedModel);
             model.getEntityManager()
                  .persist(existing);
         }

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/authentication/CoreUser.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/authentication/CoreUser.java
@@ -28,6 +28,8 @@ import com.chiralbehaviors.CoRE.phantasm.ScopedPhantasm;
 import com.chiralbehaviors.bcrypt.BCrypt;
 
 /**
+ * A custom Phantasm for manipulating user accounts.
+ * 
  * @author hhildebrand
  *
  */

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -196,7 +196,7 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                                   (RuleForm) update.get(AT_RULEFORM),
                                                                   auth,
                                                                   (Object) update.get(setter)));
-            inputType = new GraphQLList(GraphQLString);
+            inputType = GraphQLString;
         }
         updateTypeBuilder.field(newInputObjectField().type(inputType)
                                                      .name(setter)

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -163,8 +163,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         typeBuilder.field(newFieldDefinition().type(type)
                                               .name(fieldName)
                                               .description(attribute.getDescription())
-                                              .dataFetcher(env -> ctx(env).getAttributeValue((RuleForm) env.getSource(),
-                                                                                             auth))
+                                              .dataFetcher(env -> ctx(env).getAttributeValue(facet,
+                                                                                             (RuleForm) env.getSource(), auth))
                                               .build());
 
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
@@ -188,9 +188,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         } else {
             updateTemplate.put(setter,
                                (crud,
-                                update) -> crud.setAttributeValue((RuleForm) update.get(AT_RULEFORM),
-                                                                  auth,
-                                                                  (Object) update.get(setter)));
+                                update) -> crud.setAttributeValue(facet,
+                                                                  (RuleForm) update.get(AT_RULEFORM),
+                                                                  auth, (Object) update.get(setter)));
             inputType = new GraphQLList(GraphQLString);
         }
         updateTypeBuilder.field(newInputObjectField().type(inputType)
@@ -209,8 +209,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         type = new GraphQLList(type);
         typeBuilder.field(newFieldDefinition().type(type)
                                               .name(fieldName)
-                                              .dataFetcher(env -> ctx(env).getChildren((RuleForm) env.getSource(),
-                                                                                       auth))
+                                              .dataFetcher(env -> ctx(env).getChildren(facet,
+                                                                                       (RuleForm) env.getSource(), auth))
                                               .description(auth.getNotes())
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
@@ -233,9 +233,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(add,
                            (crud,
-                            update) -> crud.addChild((RuleForm) update.get(AT_RULEFORM),
-                                                     auth,
-                                                     (RuleForm) crud.lookup(auth,
+                            update) -> crud.addChild(facet,
+                                                     (RuleForm) update.get(AT_RULEFORM),
+                                                     auth, (RuleForm) crud.lookup(auth,
                                                                             (String) update.get(add))));
 
         String remove = String.format(REMOVE_TEMPLATE,
@@ -272,9 +272,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(addChildren,
                            (crud,
-                            update) -> crud.addChildren((RuleForm) update.get(AT_RULEFORM),
-                                                        auth,
-                                                        (List<RuleForm>) crud.lookupRuleForm(auth,
+                            update) -> crud.addChildren(facet,
+                                                        (RuleForm) update.get(AT_RULEFORM),
+                                                        auth, (List<RuleForm>) crud.lookupRuleForm(auth,
                                                                                              (List<String>) update.get(addChildren))));
         references.add(child);
     }
@@ -288,8 +288,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         typeBuilder.field(newFieldDefinition().type(type)
                                               .name(fieldName)
                                               .description(auth.getNotes())
-                                              .dataFetcher(env -> ctx(env).getChildren((RuleForm) env.getSource(),
-                                                                                       auth))
+                                              .dataFetcher(env -> ctx(env).getChildren(facet,
+                                                                                       (RuleForm) env.getSource(), auth))
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
         updateTypeBuilder.field(newInputObjectField().type(new GraphQLList(GraphQLString))
@@ -311,9 +311,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(add,
                            (crud,
-                            update) -> crud.addChild((RuleForm) update.get(AT_RULEFORM),
-                                                     auth,
-                                                     crud.lookup(child,
+                            update) -> crud.addChild(facet,
+                                                     (RuleForm) update.get(AT_RULEFORM),
+                                                     auth, crud.lookup(child,
                                                                  (String) update.get(add))));
 
         String remove = String.format(REMOVE_TEMPLATE,
@@ -350,9 +350,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(addChildren,
                            (crud,
-                            update) -> crud.addChildren((RuleForm) update.get(AT_RULEFORM),
-                                                        auth,
-                                                        crud.lookup(child,
+                            update) -> crud.addChildren(facet,
+                                                        (RuleForm) update.get(AT_RULEFORM),
+                                                        auth, crud.lookup(child,
                                                                     (List<String>) update.get(addChildren))));
         references.add(child);
     }
@@ -365,8 +365,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         GraphQLOutputType type = new GraphQLTypeReference(child.getName());
         typeBuilder.field(newFieldDefinition().type(type)
                                               .name(fieldName)
-                                              .dataFetcher(env -> ctx(env).getSingularChild((RuleForm) env.getSource(),
-                                                                                            auth))
+                                              .dataFetcher(env -> ctx(env).getSingularChild(facet,
+                                                                                            (RuleForm) env.getSource(), auth))
                                               .description(auth.getNotes())
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
@@ -392,7 +392,7 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                               .name(fieldName)
                                               .description(auth.getNotes())
                                               .dataFetcher(env -> ctx(env).getSingularChild((RuleForm) env.getSource(),
-                                                                                            auth))
+                                                                                            auth, facet))
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
         updateTypeBuilder.field(newInputObjectField().type(GraphQLString)

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -164,7 +164,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                               .name(fieldName)
                                               .description(attribute.getDescription())
                                               .dataFetcher(env -> ctx(env).getAttributeValue(facet,
-                                                                                             (RuleForm) env.getSource(), auth))
+                                                                                             (RuleForm) env.getSource(),
+                                                                                             auth))
                                               .build());
 
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
@@ -175,7 +176,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                (crud,
                                 update) -> crud.setAttributeValue(facet,
                                                                   (RuleForm) update.get(AT_RULEFORM),
-                                                                  auth, (List<Object>) update.get(setter)));
+                                                                  auth,
+                                                                  (List<Object>) update.get(setter)));
             inputType = new GraphQLList(GraphQLString);
         } else if (auth.getAuthorizedAttribute()
                        .getKeyed()) {
@@ -183,14 +185,16 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                (crud,
                                 update) -> crud.setAttributeValue(facet,
                                                                   (RuleForm) update.get(AT_RULEFORM),
-                                                                  auth, (Map<String, Object>) update.get(setter)));
+                                                                  auth,
+                                                                  (Map<String, Object>) update.get(setter)));
             inputType = GraphQLString;
         } else {
             updateTemplate.put(setter,
                                (crud,
                                 update) -> crud.setAttributeValue(facet,
                                                                   (RuleForm) update.get(AT_RULEFORM),
-                                                                  auth, (Object) update.get(setter)));
+                                                                  auth,
+                                                                  (Object) update.get(setter)));
             inputType = new GraphQLList(GraphQLString);
         }
         updateTypeBuilder.field(newInputObjectField().type(inputType)
@@ -210,7 +214,16 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         typeBuilder.field(newFieldDefinition().type(type)
                                               .name(fieldName)
                                               .dataFetcher(env -> ctx(env).getChildren(facet,
-                                                                                       (RuleForm) env.getSource(), auth))
+                                                                                       (RuleForm) env.getSource(),
+                                                                                       auth))
+                                              .description(auth.getNotes())
+                                              .build());
+        typeBuilder.field(newFieldDefinition().type(type)
+                                              .name(String.format("immediate%s",
+                                                                  capitalized(fieldName)))
+                                              .dataFetcher(env -> ctx(env).getImmediateChildren(facet,
+                                                                                                (RuleForm) env.getSource(),
+                                                                                                auth))
                                               .description(auth.getNotes())
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
@@ -222,7 +235,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.setChildren(facet,
                                                         (RuleForm) update.get(AT_RULEFORM),
-                                                        auth, (List<RuleForm>) crud.lookupRuleForm(auth,
+                                                        auth,
+                                                        (List<RuleForm>) crud.lookupRuleForm(auth,
                                                                                              (List<String>) update.get(setter))));
 
         String add = String.format(ADD_TEMPLATE,
@@ -235,7 +249,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.addChild(facet,
                                                      (RuleForm) update.get(AT_RULEFORM),
-                                                     auth, (RuleForm) crud.lookup(auth,
+                                                     auth,
+                                                     (RuleForm) crud.lookup(auth,
                                                                             (String) update.get(add))));
 
         String remove = String.format(REMOVE_TEMPLATE,
@@ -248,7 +263,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.removeChild(facet,
                                                         (RuleForm) update.get(AT_RULEFORM),
-                                                        auth, (RuleForm) crud.lookup(auth,
+                                                        auth,
+                                                        (RuleForm) crud.lookup(auth,
                                                                                (String) update.get(remove))));
 
         String removeChildren = String.format(REMOVE_TEMPLATE,
@@ -261,7 +277,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.removeChildren(facet,
                                                            (RuleForm) update.get(AT_RULEFORM),
-                                                           auth, (List<RuleForm>) crud.lookupRuleForm(auth,
+                                                           auth,
+                                                           (List<RuleForm>) crud.lookupRuleForm(auth,
                                                                                                 (List<String>) update.get(removeChildren))));
 
         String addChildren = String.format(ADD_TEMPLATE,
@@ -274,7 +291,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.addChildren(facet,
                                                         (RuleForm) update.get(AT_RULEFORM),
-                                                        auth, (List<RuleForm>) crud.lookupRuleForm(auth,
+                                                        auth,
+                                                        (List<RuleForm>) crud.lookupRuleForm(auth,
                                                                                              (List<String>) update.get(addChildren))));
         references.add(child);
     }
@@ -289,7 +307,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                               .name(fieldName)
                                               .description(auth.getNotes())
                                               .dataFetcher(env -> ctx(env).getChildren(facet,
-                                                                                       (RuleForm) env.getSource(), auth))
+                                                                                       (RuleForm) env.getSource(),
+                                                                                       auth))
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
         updateTypeBuilder.field(newInputObjectField().type(new GraphQLList(GraphQLString))
@@ -300,7 +319,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.setChildren(facet,
                                                         (RuleForm) update.get(AT_RULEFORM),
-                                                        auth, crud.lookup(child,
+                                                        auth,
+                                                        crud.lookup(child,
                                                                     (List<String>) update.get(setter))));
 
         String add = String.format(ADD_TEMPLATE,
@@ -313,7 +333,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.addChild(facet,
                                                      (RuleForm) update.get(AT_RULEFORM),
-                                                     auth, crud.lookup(child,
+                                                     auth,
+                                                     crud.lookup(child,
                                                                  (String) update.get(add))));
 
         String remove = String.format(REMOVE_TEMPLATE,
@@ -326,7 +347,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.removeChild(facet,
                                                         (RuleForm) update.get(AT_RULEFORM),
-                                                        auth, crud.lookup(child,
+                                                        auth,
+                                                        crud.lookup(child,
                                                                     (String) update.get(remove))));
 
         String removeChildren = String.format(REMOVE_TEMPLATE,
@@ -339,7 +361,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.removeChildren(facet,
                                                            (RuleForm) update.get(AT_RULEFORM),
-                                                           auth, crud.lookup(child,
+                                                           auth,
+                                                           crud.lookup(child,
                                                                        (List<String>) update.get(removeChildren))));
 
         String addChildren = String.format(ADD_TEMPLATE,
@@ -352,7 +375,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.addChildren(facet,
                                                         (RuleForm) update.get(AT_RULEFORM),
-                                                        auth, crud.lookup(child,
+                                                        auth,
+                                                        crud.lookup(child,
                                                                     (List<String>) update.get(addChildren))));
         references.add(child);
     }
@@ -366,7 +390,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
         typeBuilder.field(newFieldDefinition().type(type)
                                               .name(fieldName)
                                               .dataFetcher(env -> ctx(env).getSingularChild(facet,
-                                                                                            (RuleForm) env.getSource(), auth))
+                                                                                            (RuleForm) env.getSource(),
+                                                                                            auth))
                                               .description(auth.getNotes())
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
@@ -378,7 +403,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.setSingularChild(facet,
                                                              (RuleForm) update.get(AT_RULEFORM),
-                                                             auth, (RuleForm) crud.lookup(auth,
+                                                             auth,
+                                                             (RuleForm) crud.lookup(auth,
                                                                                     (String) update.get(setter))));
         references.add(child);
     }
@@ -392,7 +418,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                               .name(fieldName)
                                               .description(auth.getNotes())
                                               .dataFetcher(env -> ctx(env).getSingularChild((RuleForm) env.getSource(),
-                                                                                            auth, facet))
+                                                                                            auth,
+                                                                                            facet))
                                               .build());
         String setter = String.format(SET_TEMPLATE, capitalized(fieldName));
         updateTypeBuilder.field(newInputObjectField().type(GraphQLString)
@@ -403,7 +430,8 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                            (crud,
                             update) -> crud.setSingularChild(facet,
                                                              (RuleForm) update.get(AT_RULEFORM),
-                                                             auth, crud.lookup(child,
+                                                             auth,
+                                                             crud.lookup(child,
                                                                          (String) update.get(setter))));
         references.add(child);
     }

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -173,17 +173,17 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                 .getIndexed()) {
             updateTemplate.put(setter,
                                (crud,
-                                update) -> crud.setAttributeValue((RuleForm) update.get(AT_RULEFORM),
-                                                                  auth,
-                                                                  (List<Object>) update.get(setter)));
+                                update) -> crud.setAttributeValue(facet,
+                                                                  (RuleForm) update.get(AT_RULEFORM),
+                                                                  auth, (List<Object>) update.get(setter)));
             inputType = new GraphQLList(GraphQLString);
         } else if (auth.getAuthorizedAttribute()
                        .getKeyed()) {
             updateTemplate.put(setter,
                                (crud,
-                                update) -> crud.setAttributeValue((RuleForm) update.get(AT_RULEFORM),
-                                                                  auth,
-                                                                  (Map<String, Object>) update.get(setter)));
+                                update) -> crud.setAttributeValue(facet,
+                                                                  (RuleForm) update.get(AT_RULEFORM),
+                                                                  auth, (Map<String, Object>) update.get(setter)));
             inputType = GraphQLString;
         } else {
             updateTemplate.put(setter,
@@ -220,9 +220,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(setter,
                            (crud,
-                            update) -> crud.setChildren((RuleForm) update.get(AT_RULEFORM),
-                                                        auth,
-                                                        (List<RuleForm>) crud.lookupRuleForm(auth,
+                            update) -> crud.setChildren(facet,
+                                                        (RuleForm) update.get(AT_RULEFORM),
+                                                        auth, (List<RuleForm>) crud.lookupRuleForm(auth,
                                                                                              (List<String>) update.get(setter))));
 
         String add = String.format(ADD_TEMPLATE,
@@ -246,9 +246,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(remove,
                            (crud,
-                            update) -> crud.removeChild((RuleForm) update.get(AT_RULEFORM),
-                                                        auth,
-                                                        (RuleForm) crud.lookup(auth,
+                            update) -> crud.removeChild(facet,
+                                                        (RuleForm) update.get(AT_RULEFORM),
+                                                        auth, (RuleForm) crud.lookup(auth,
                                                                                (String) update.get(remove))));
 
         String removeChildren = String.format(REMOVE_TEMPLATE,
@@ -259,9 +259,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(removeChildren,
                            (crud,
-                            update) -> crud.removeChildren((RuleForm) update.get(AT_RULEFORM),
-                                                           auth,
-                                                           (List<RuleForm>) crud.lookupRuleForm(auth,
+                            update) -> crud.removeChildren(facet,
+                                                           (RuleForm) update.get(AT_RULEFORM),
+                                                           auth, (List<RuleForm>) crud.lookupRuleForm(auth,
                                                                                                 (List<String>) update.get(removeChildren))));
 
         String addChildren = String.format(ADD_TEMPLATE,
@@ -298,9 +298,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(setter,
                            (crud,
-                            update) -> crud.setChildren((RuleForm) update.get(AT_RULEFORM),
-                                                        auth,
-                                                        crud.lookup(child,
+                            update) -> crud.setChildren(facet,
+                                                        (RuleForm) update.get(AT_RULEFORM),
+                                                        auth, crud.lookup(child,
                                                                     (List<String>) update.get(setter))));
 
         String add = String.format(ADD_TEMPLATE,
@@ -324,9 +324,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(remove,
                            (crud,
-                            update) -> crud.removeChild((RuleForm) update.get(AT_RULEFORM),
-                                                        auth,
-                                                        crud.lookup(child,
+                            update) -> crud.removeChild(facet,
+                                                        (RuleForm) update.get(AT_RULEFORM),
+                                                        auth, crud.lookup(child,
                                                                     (String) update.get(remove))));
 
         String removeChildren = String.format(REMOVE_TEMPLATE,
@@ -337,9 +337,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(removeChildren,
                            (crud,
-                            update) -> crud.removeChildren((RuleForm) update.get(AT_RULEFORM),
-                                                           auth,
-                                                           crud.lookup(child,
+                            update) -> crud.removeChildren(facet,
+                                                           (RuleForm) update.get(AT_RULEFORM),
+                                                           auth, crud.lookup(child,
                                                                        (List<String>) update.get(removeChildren))));
 
         String addChildren = String.format(ADD_TEMPLATE,
@@ -376,9 +376,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(setter,
                            (crud,
-                            update) -> crud.setSingularChild((RuleForm) update.get(AT_RULEFORM),
-                                                             auth,
-                                                             (RuleForm) crud.lookup(auth,
+                            update) -> crud.setSingularChild(facet,
+                                                             (RuleForm) update.get(AT_RULEFORM),
+                                                             auth, (RuleForm) crud.lookup(auth,
                                                                                     (String) update.get(setter))));
         references.add(child);
     }
@@ -401,9 +401,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                                      .build());
         updateTemplate.put(setter,
                            (crud,
-                            update) -> crud.setSingularChild((RuleForm) update.get(AT_RULEFORM),
-                                                             auth,
-                                                             crud.lookup(child,
+                            update) -> crud.setSingularChild(facet,
+                                                             (RuleForm) update.get(AT_RULEFORM),
+                                                             auth, crud.lookup(child,
                                                                          (String) update.get(setter))));
         references.add(child);
     }

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -72,6 +72,7 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
     private static final String CREATE_MUTATION    = "Create%s";
     private static final String DESCRIPTION        = "description";
     private static final String ID                 = "id";
+    private static final String IMMEDIATE_TEMPLATE = "immediate%s";
     private static final String INSTANCES_OF_QUERY = "InstancesOf%s";
     private static final String NAME               = "name";
     private static final String REMOVE_MUTATION    = "Remove%s";
@@ -219,7 +220,7 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                               .description(auth.getNotes())
                                               .build());
         typeBuilder.field(newFieldDefinition().type(type)
-                                              .name(String.format("immediate%s",
+                                              .name(String.format(IMMEDIATE_TEMPLATE,
                                                                   capitalized(fieldName)))
                                               .dataFetcher(env -> ctx(env).getImmediateChildren(facet,
                                                                                                 (RuleForm) env.getSource(),

--- a/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/graphQl/WorkspaceSchemaTest.java
+++ b/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/graphQl/WorkspaceSchemaTest.java
@@ -20,12 +20,14 @@
 
 package com.chiralbehaviors.CoRE.phantasm.graphQl;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -190,8 +192,10 @@ public class WorkspaceSchemaTest extends AbstractModelTest {
         variables.put("artifact", artifact2.getRuleform()
                                            .getId()
                                            .toString());
+        String[] newAliases = new String[] { "jones", "smith" };
+        variables.put("aliases", Arrays.asList(newAliases));
         variables.put("name", "hello");
-        QueryRequest request = new QueryRequest("mutation m($id: String, $name: String, $artifact: String) { UpdateThing1(state: { id: $id, setName: $name, setDerivedFrom: $artifact}) { name } }",
+        QueryRequest request = new QueryRequest("mutation m($id: String, $name: String, $artifact: String, $aliases: [String]) { UpdateThing1(state: { id: $id, setName: $name, setDerivedFrom: $artifact, setAliases: $aliases}) { name } }",
                                                 variables);
         Map<String, Object> result;
         try {
@@ -211,8 +215,8 @@ public class WorkspaceSchemaTest extends AbstractModelTest {
         Map<String, Object> thing1Result = (Map<String, Object>) result.get("UpdateThing1");
         assertNotNull(thing1Result);
         assertEquals(thing1.getName(), thing1Result.get("name"));
-
         assertEquals(artifact2, thing1.getDerivedFrom());
+        assertArrayEquals(newAliases, thing1.getAliases());
     }
 
     @Test

--- a/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/graphQl/WorkspaceSchemaTest.java
+++ b/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/graphQl/WorkspaceSchemaTest.java
@@ -151,6 +151,8 @@ public class WorkspaceSchemaTest extends AbstractModelTest {
     public void testMutation() throws Exception {
         em.getTransaction()
           .begin();
+        String[] newAliases = new String[] { "jones", "smith" };
+        String newUri = "new iri";
         WorkspaceImporter.createWorkspace(ResourcesTest.class.getResourceAsStream("/thing.wsp"),
                                           model);
         Thing1 thing1 = model.construct(Thing1.class, "test", "testy");
@@ -192,10 +194,10 @@ public class WorkspaceSchemaTest extends AbstractModelTest {
         variables.put("artifact", artifact2.getRuleform()
                                            .getId()
                                            .toString());
-        String[] newAliases = new String[] { "jones", "smith" };
         variables.put("aliases", Arrays.asList(newAliases));
         variables.put("name", "hello");
-        QueryRequest request = new QueryRequest("mutation m($id: String, $name: String, $artifact: String, $aliases: [String]) { UpdateThing1(state: { id: $id, setName: $name, setDerivedFrom: $artifact, setAliases: $aliases}) { name } }",
+        variables.put("uri", newUri);
+        QueryRequest request = new QueryRequest("mutation m($id: String, $name: String, $artifact: String, $aliases: [String], $uri: String) { UpdateThing1(state: { id: $id, setName: $name, setDerivedFrom: $artifact, setAliases: $aliases, setURI: $uri}) { name } }",
                                                 variables);
         Map<String, Object> result;
         try {
@@ -217,6 +219,7 @@ public class WorkspaceSchemaTest extends AbstractModelTest {
         assertEquals(thing1.getName(), thing1Result.get("name"));
         assertEquals(artifact2, thing1.getDerivedFrom());
         assertArrayEquals(newAliases, thing1.getAliases());
+        assertEquals(newUri, thing1.getURI());
     }
 
     @Test

--- a/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/graphQl/WorkspaceSchemaTest.java
+++ b/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/graphQl/WorkspaceSchemaTest.java
@@ -39,13 +39,13 @@ import org.junit.Test;
 
 import com.chiralbehaviors.CoRE.meta.models.AbstractModelTest;
 import com.chiralbehaviors.CoRE.meta.workspace.dsl.WorkspaceImporter;
-import com.chiralbehaviors.CoRE.phantasm.jsonld.resources.ResourcesTest;
 import com.chiralbehaviors.CoRE.phantasm.model.PhantasmCRUD;
 import com.chiralbehaviors.CoRE.phantasm.resource.test.location.MavenArtifact;
 import com.chiralbehaviors.CoRE.phantasm.resource.test.product.Thing1;
 import com.chiralbehaviors.CoRE.phantasm.resource.test.product.Thing2;
 import com.chiralbehaviors.CoRE.phantasm.resource.test.product.Thing3;
 import com.chiralbehaviors.CoRE.phantasm.resources.GraphQlResource;
+import com.chiralbehaviors.CoRE.phantasm.resources.ResourcesTest;
 import com.chiralbehaviors.CoRE.phantasm.resources.GraphQlResource.QueryRequest;
 
 import graphql.ExecutionResult;

--- a/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/resources/test/JpaConfiguration.java
+++ b/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/resources/test/JpaConfiguration.java
@@ -13,31 +13,41 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License.
  */
-package com.chiralbehaviors.CoRE.phantasm.jsonld.resources.test;
-
-import javax.validation.constraints.NotNull;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+package com.chiralbehaviors.CoRE.phantasm.resources.test;
 
 import io.dropwizard.Configuration;
+
+import java.util.Map;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author hhildebrand
  * 
  */
-public class TestServiceConfiguration extends Configuration {
+public class JpaConfiguration extends Configuration {
     @JsonProperty
-    private Boolean randomPort = false;
+    private boolean             debug = false;
 
-    @NotNull
+    @NotEmpty
     @JsonProperty
-    private JpaConfiguration jpa = new JpaConfiguration();
+    private String              persistenceUnit;
 
-    public JpaConfiguration getCrudServiceConfiguration() {
-        return jpa;
+    @NotEmpty
+    @JsonProperty
+    private Map<String, String> properties;
+
+    public String getPersistenceUnit() {
+        return persistenceUnit;
     }
 
-    public Boolean isRandomPort() {
-        return randomPort;
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public boolean isDebug() {
+        return debug;
     }
 }

--- a/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/resources/test/TestApplication.java
+++ b/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/resources/test/TestApplication.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.chiralbehaviors.CoRE.phantasm.jsonld.resources.test;
+package com.chiralbehaviors.CoRE.phantasm.resources.test;
 
 import java.util.Map;
 

--- a/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/resources/test/TestServiceConfiguration.java
+++ b/phantasm-at-rest/src/test/java/com/chiralbehaviors/CoRE/phantasm/resources/test/TestServiceConfiguration.java
@@ -13,41 +13,31 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License.
  */
-package com.chiralbehaviors.CoRE.phantasm.jsonld.resources.test;
+package com.chiralbehaviors.CoRE.phantasm.resources.test;
 
-import io.dropwizard.Configuration;
-
-import java.util.Map;
-
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.dropwizard.Configuration;
 
 /**
  * @author hhildebrand
  * 
  */
-public class JpaConfiguration extends Configuration {
+public class TestServiceConfiguration extends Configuration {
     @JsonProperty
-    private boolean             debug = false;
+    private Boolean randomPort = false;
 
-    @NotEmpty
+    @NotNull
     @JsonProperty
-    private String              persistenceUnit;
+    private JpaConfiguration jpa = new JpaConfiguration();
 
-    @NotEmpty
-    @JsonProperty
-    private Map<String, String> properties;
-
-    public String getPersistenceUnit() {
-        return persistenceUnit;
+    public JpaConfiguration getCrudServiceConfiguration() {
+        return jpa;
     }
 
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    public boolean isDebug() {
-        return debug;
+    public Boolean isRandomPort() {
+        return randomPort;
     }
 }


### PR DESCRIPTION
set singular/array attributes.  a lot of refactoring to normalize capability checks.  check facet{read/update} capability in addition to state auth capability.  add state accessor for immediate (as opposed to immediate+inferred) children. change capability check semantics from security exception to silent fail, to comply with graphql.