### PR TITLE
Add bound variable validation for graphql.

### DIFF
--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/VariablesAreBoundRule.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/VariablesAreBoundRule.java
@@ -1,0 +1,38 @@
+package com.chiralbehaviors.CoRE.phantasm.graphql;
+
+import java.util.Map;
+
+import graphql.language.VariableReference;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationError;
+import graphql.validation.ValidationErrorCollector;
+import graphql.validation.ValidationErrorType;
+import graphql.validation.rules.VariablesTypesMatcher;
+
+public class VariablesAreBoundRule extends AbstractRule {
+
+    private final Map<String, Object> variables;
+    VariablesTypesMatcher             variablesTypesMatcher = new VariablesTypesMatcher();
+
+    public VariablesAreBoundRule(ValidationContext validationContext,
+                                 ValidationErrorCollector validationErrorCollector,
+                                 Map<String, Object> variables) {
+        super(validationContext, validationErrorCollector);
+        setVisitFragmentSpreads(true);
+        this.variables = variables;
+    }
+
+    @Override
+    public void checkVariable(VariableReference variableReference) {
+        if (variables.containsKey(variableReference.getName())) {
+            return;
+        }
+        String message = String.format("Variable not bound: '$%s'",
+                                       variableReference.getName());
+        addError(new ValidationError(ValidationErrorType.UnboundVariable,
+                                     variableReference.getSourceLocation(),
+                                     message));
+    }
+
+}

--- a/phantasm-at-rest/src/main/java/graphql/GraphQL.java
+++ b/phantasm-at-rest/src/main/java/graphql/GraphQL.java
@@ -1,0 +1,86 @@
+package graphql;
+
+import static graphql.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import org.antlr.v4.runtime.RecognitionException;
+
+import graphql.execution.Execution;
+import graphql.language.Document;
+import graphql.language.SourceLocation;
+import graphql.parser.Parser;
+import graphql.schema.GraphQLSchema;
+import graphql.validation.ValidationError;
+import graphql.validation.Validator;
+
+public class GraphQL {
+
+    private final GraphQLSchema   graphQLSchema;
+    private final ExecutorService executorService;
+
+    public GraphQL(GraphQLSchema graphQLSchema) {
+        this(graphQLSchema, null);
+    }
+
+    public GraphQL(GraphQLSchema graphQLSchema,
+                   ExecutorService executorService) {
+        this.graphQLSchema = graphQLSchema;
+        this.executorService = executorService;
+    }
+
+    public ExecutionResult execute(String requestString) {
+        return execute(requestString, null);
+    }
+
+    public ExecutionResult execute(String requestString, Object context) {
+        return execute(requestString, context,
+                       Collections.<String, Object> emptyMap());
+    }
+
+    public ExecutionResult execute(String requestString, String operationName,
+                                   Object context) {
+        return execute(requestString, operationName, context,
+                       Collections.<String, Object> emptyMap());
+    }
+
+    public ExecutionResult execute(String requestString, Object context,
+                                   Map<String, Object> arguments) {
+        return execute(requestString, null, context, arguments);
+    }
+
+    public ExecutionResult execute(String requestString, String operationName,
+                                   Object context,
+                                   Map<String, Object> arguments) {
+        assertNotNull(arguments, "arguments can't be null");
+        Parser parser = new Parser();
+        Document document;
+        try {
+            document = parser.parseDocument(requestString);
+        } catch (RecognitionException e) {
+            SourceLocation sourceLocation = new SourceLocation(e.getOffendingToken()
+                                                                .getLine(),
+                                                               e.getOffendingToken()
+                                                                .getCharPositionInLine());
+            InvalidSyntaxError invalidSyntaxError = new InvalidSyntaxError(sourceLocation);
+            return new ExecutionResultImpl(Arrays.asList(invalidSyntaxError));
+        }
+
+        Validator validator = new Validator();
+        List<ValidationError> validationErrors = validator.validateDocument(graphQLSchema,
+                                                                            document,
+                                                                            arguments);
+        if (validationErrors.size() > 0) {
+            ExecutionResult result = new ExecutionResultImpl(validationErrors);
+            return result;
+        }
+        Execution execution = new Execution(executorService);
+        return execution.execute(graphQLSchema, context, document,
+                                 operationName, arguments);
+    }
+
+}

--- a/phantasm-at-rest/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/phantasm-at-rest/src/main/java/graphql/validation/ValidationErrorType.java
@@ -1,0 +1,14 @@
+package graphql.validation;
+
+public enum ValidationErrorType {
+
+    DefaultForNonNullArgument, WrongType, UnknownType, SubSelectionRequired,
+    SubSelectionNotAllowed, InvalidSyntax, BadValueForDefaultArg,
+    FieldUndefined, InlineFragmentTypeConditionInvalid,
+    FragmentTypeConditionInvalid, UnknownArgument, UndefinedFragment,
+    NonInputTypeOnVariable, UnusedFragment, MissingFieldArgument,
+    MissingDirectiveArgument, VariableTypeMismatch, UnknownDirective,
+    MisplacedDirective, UndefinedVariable, UnusedVariable, FragmentCycle,
+    FieldsConflict, InvalidFragmentType, UnboundVariable
+
+}

--- a/phantasm-at-rest/src/main/java/graphql/validation/Validator.java
+++ b/phantasm-at-rest/src/main/java/graphql/validation/Validator.java
@@ -1,0 +1,109 @@
+package graphql.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.chiralbehaviors.CoRE.phantasm.graphql.VariablesAreBoundRule;
+
+import graphql.language.Document;
+import graphql.schema.GraphQLSchema;
+import graphql.validation.rules.ArgumentsOfCorrectType;
+import graphql.validation.rules.FieldsOnCorrectType;
+import graphql.validation.rules.FragmentsOnCompositeType;
+import graphql.validation.rules.KnownArgumentNames;
+import graphql.validation.rules.KnownFragmentNames;
+import graphql.validation.rules.KnownTypeNames;
+import graphql.validation.rules.NoFragmentCycles;
+import graphql.validation.rules.NoUndefinedVariables;
+import graphql.validation.rules.NoUnusedFragments;
+import graphql.validation.rules.NoUnusedVariables;
+import graphql.validation.rules.OverlappingFieldsCanBeMerged;
+import graphql.validation.rules.PossibleFragmentSpreads;
+import graphql.validation.rules.ProvidedNonNullArguments;
+import graphql.validation.rules.ScalarLeafs;
+import graphql.validation.rules.VariableDefaultValuesOfCorrectType;
+import graphql.validation.rules.VariableTypesMatchRule;
+import graphql.validation.rules.VariablesAreInputTypes;
+
+public class Validator {
+
+    public List<ValidationError> validateDocument(GraphQLSchema schema,
+                                                  Document document,
+                                                  Map<String, Object> arguments) {
+        ValidationContext validationContext = new ValidationContext(schema,
+                                                                    document);
+
+        ValidationErrorCollector validationErrorCollector = new ValidationErrorCollector();
+        List<AbstractRule> rules = createRules(validationContext,
+                                               validationErrorCollector,
+                                               arguments);
+        LanguageTraversal languageTraversal = new LanguageTraversal();
+        languageTraversal.traverse(document,
+                                   new RulesVisitor(validationContext, rules));
+
+        return validationErrorCollector.getErrors();
+    }
+
+    private List<AbstractRule> createRules(ValidationContext validationContext,
+                                           ValidationErrorCollector validationErrorCollector,
+                                           Map<String, Object> arguments) {
+        List<AbstractRule> rules = new ArrayList<>();
+        ArgumentsOfCorrectType argumentsOfCorrectType = new ArgumentsOfCorrectType(validationContext,
+                                                                                   validationErrorCollector);
+        rules.add(argumentsOfCorrectType);
+        VariableDefaultValuesOfCorrectType variableDefaultValuesOfCorrectType = new VariableDefaultValuesOfCorrectType(validationContext,
+                                                                                                                       validationErrorCollector);
+        rules.add(variableDefaultValuesOfCorrectType);
+        FieldsOnCorrectType fieldsOnCorrectType = new FieldsOnCorrectType(validationContext,
+                                                                          validationErrorCollector);
+        rules.add(fieldsOnCorrectType);
+        FragmentsOnCompositeType fragmentsOnCompositeType = new FragmentsOnCompositeType(validationContext,
+                                                                                         validationErrorCollector);
+        rules.add(fragmentsOnCompositeType);
+        KnownArgumentNames knownArgumentNames = new KnownArgumentNames(validationContext,
+                                                                       validationErrorCollector);
+        rules.add(knownArgumentNames);
+        KnownFragmentNames knownFragmentNames = new KnownFragmentNames(validationContext,
+                                                                       validationErrorCollector);
+        rules.add(knownFragmentNames);
+        KnownTypeNames knownTypeNames = new KnownTypeNames(validationContext,
+                                                           validationErrorCollector);
+        rules.add(knownTypeNames);
+        NoFragmentCycles noFragmentCycles = new NoFragmentCycles(validationContext,
+                                                                 validationErrorCollector);
+        rules.add(noFragmentCycles);
+        NoUndefinedVariables noUndefinedVariables = new NoUndefinedVariables(validationContext,
+                                                                             validationErrorCollector);
+        rules.add(noUndefinedVariables);
+        NoUnusedFragments noUnusedFragments = new NoUnusedFragments(validationContext,
+                                                                    validationErrorCollector);
+        rules.add(noUnusedFragments);
+        NoUnusedVariables noUnusedVariables = new NoUnusedVariables(validationContext,
+                                                                    validationErrorCollector);
+        rules.add(noUnusedVariables);
+        OverlappingFieldsCanBeMerged overlappingFieldsCanBeMerged = new OverlappingFieldsCanBeMerged(validationContext,
+                                                                                                     validationErrorCollector);
+        rules.add(overlappingFieldsCanBeMerged);
+        PossibleFragmentSpreads possibleFragmentSpreads = new PossibleFragmentSpreads(validationContext,
+                                                                                      validationErrorCollector);
+        rules.add(possibleFragmentSpreads);
+        ProvidedNonNullArguments providedNonNullArguments = new ProvidedNonNullArguments(validationContext,
+                                                                                         validationErrorCollector);
+        rules.add(providedNonNullArguments);
+        ScalarLeafs scalarLeafs = new ScalarLeafs(validationContext,
+                                                  validationErrorCollector);
+        rules.add(scalarLeafs);
+        VariablesAreInputTypes variablesAreInputTypes = new VariablesAreInputTypes(validationContext,
+                                                                                   validationErrorCollector);
+        rules.add(variablesAreInputTypes);
+        VariableTypesMatchRule variableTypesMatchRule = new VariableTypesMatchRule(validationContext,
+                                                                                   validationErrorCollector);
+        rules.add(variableTypesMatchRule);
+        VariablesAreBoundRule variablesAreBoundRule = new VariablesAreBoundRule(validationContext,
+                                                                                validationErrorCollector,
+                                                                                arguments);
+        rules.add(variablesAreBoundRule);
+        return rules;
+    }
+}


### PR DESCRIPTION
Patch the graphql library to add validation for unbound variables, rather than throwing a cryptic NPE.  A now useful validation error is produced, complete with type and detailed message.