### PR TITLE
Active roles

### DIFF
--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/NetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/NetworkedModel.java
@@ -143,9 +143,9 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                            Relationship authorized);
 
     /**
-     * Check the capability of an agency on an attribute of a ruleform.
+     * Check the capability of the agencies on an attribute of a ruleform.
      */
-    boolean checkCapability(Agency agency,
+    boolean checkCapability(List<Agency> agencies,
                             AttributeAuthorization<RuleForm, ?> stateAuth,
                             Relationship capability);
 
@@ -157,10 +157,11 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
-     * Check the capability of an agency on an instance.
+     * Check the capability of the agencies on an instance.
      */
-    boolean checkCapability(Agency agency, ExistentialRuleform<?, ?> instance,
-                            Relationship capability);
+    boolean checkCapability(List<Agency> agencies,
+                                    ExistentialRuleform<?, ?> instance,
+                                    Relationship capability);
 
     /**
      * Check the capability of the current principal on an instance.
@@ -169,10 +170,11 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
-     * Check the capability of an agency on the authorized relationship of the
-     * facet child relationship.
+     * Check the capability of the agencies on the authorized relationship of
+     * the facet child relationship.
      */
-    boolean checkCapability(Agency agency, NetworkAuthorization<RuleForm> auth,
+    boolean checkCapability(List<Agency> agencies,
+                            NetworkAuthorization<RuleForm> auth,
                             Relationship capability);
 
     /**
@@ -183,10 +185,10 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
-     * Check the capability of an agency on an attribute of the authorized cross
-     * domain relationship of the facet child relationship.
+     * Check the capability of the agencies on an attribute of the authorized
+     * cross domain relationship of the facet child relationship.
      */
-    boolean checkCapability(Agency agency,
+    boolean checkCapability(List<Agency> agencies,
                             XDomainAttrbuteAuthorization<?, ?> stateAuth,
                             Relationship capability);
 
@@ -198,10 +200,10 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
-     * Check the capability of an agency on the authorized relationship of the
-     * facet child relationship.
+     * Check the capability of the agencies on the authorized relationship of
+     * the facet child relationship.
      */
-    boolean checkCapability(Agency agency,
+    boolean checkCapability(List<Agency> agencies,
                             XDomainNetworkAuthorization<?, ?> stateAuth,
                             Relationship capability);
 
@@ -213,9 +215,9 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
-     * Check the capability of an agency on the facet.
+     * Check the capability of the agencies on the facet.
      */
-    boolean checkFacetCapability(Agency agency,
+    boolean checkFacetCapability(List<Agency> agencies,
                                  NetworkAuthorization<RuleForm> facet,
                                  Relationship capability);
 
@@ -226,10 +228,10 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                                  Relationship capability);
 
     /**
-     * Check the capability of an agency on an attribute of the authorized
+     * Check the capability of the agencies on an attribute of the authorized
      * relationship of the facet child relationship.
      */
-    boolean checkNetworkCapability(Agency agency,
+    boolean checkNetworkCapability(List<Agency> agencies,
                                    AttributeAuthorization<RuleForm, ?> stateAuth,
                                    Relationship capability);
 

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/NetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/NetworkedModel.java
@@ -146,7 +146,14 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
      * Check the capability of an agency on an attribute of a ruleform.
      */
     boolean checkCapability(Agency agency,
-                            AttributeAuthorization<RuleForm, ?> statAuth,
+                            AttributeAuthorization<RuleForm, ?> stateAuth,
+                            Relationship capability);
+
+    /**
+     * Check the capability of the current principal on an attribute of a
+     * ruleform.
+     */
+    boolean checkCapability(AttributeAuthorization<RuleForm, ?> stateAuth,
                             Relationship capability);
 
     /**
@@ -156,10 +163,23 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
+     * Check the capability of the current principal on an instance.
+     */
+    boolean checkCapability(ExistentialRuleform<?, ?> instance,
+                            Relationship capability);
+
+    /**
      * Check the capability of an agency on the authorized relationship of the
      * facet child relationship.
      */
     boolean checkCapability(Agency agency, NetworkAuthorization<RuleForm> auth,
+                            Relationship capability);
+
+    /**
+     * Check the capability of the current principal on the authorized
+     * relationship of the facet child relationship.
+     */
+    boolean checkCapability(NetworkAuthorization<RuleForm> auth,
                             Relationship capability);
 
     /**
@@ -171,11 +191,25 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                             Relationship capability);
 
     /**
+     * Check the capability of the current principal on an attribute of the
+     * authorized cross domain relationship of the facet child relationship.
+     */
+    boolean checkCapability(XDomainAttrbuteAuthorization<?, ?> stateAuth,
+                            Relationship capability);
+
+    /**
      * Check the capability of an agency on the authorized relationship of the
      * facet child relationship.
      */
     boolean checkCapability(Agency agency,
                             XDomainNetworkAuthorization<?, ?> stateAuth,
+                            Relationship capability);
+
+    /**
+     * Check the capability of the current principal on the authorized
+     * relationship of the facet child relationship.
+     */
+    boolean checkCapability(XDomainNetworkAuthorization<?, ?> stateAuth,
                             Relationship capability);
 
     /**
@@ -186,11 +220,24 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
                                  Relationship capability);
 
     /**
+     * Check the capability of the current principal on the facet.
+     */
+    boolean checkFacetCapability(NetworkAuthorization<RuleForm> facet,
+                                 Relationship capability);
+
+    /**
      * Check the capability of an agency on an attribute of the authorized
      * relationship of the facet child relationship.
      */
     boolean checkNetworkCapability(Agency agency,
                                    AttributeAuthorization<RuleForm, ?> stateAuth,
+                                   Relationship capability);
+
+    /**
+     * Check the capability of the current principal on an attribute of the
+     * authorized relationship of the facet child relationship.
+     */
+    boolean checkNetworkCapability(AttributeAuthorization<RuleForm, ?> stateAuth,
                                    Relationship capability);
 
     /**
@@ -323,7 +370,6 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
      * @param aspect
      *            - the classifying aspect.
      * @param includeGrouping
-     *            TODO
      * @return
      */
     List<AttributeAuth> getAttributeAuthorizations(Aspect<RuleForm> aspect,
@@ -336,7 +382,6 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
      * @param facet
      *            - the classifying aspect.
      * @param includeGrouping
-     *            TODO
      * @return
      */
     List<AttributeAuth> getAttributeAuthorizations(NetworkAuthorization<RuleForm> facet,
@@ -521,7 +566,6 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
      * 
      * @param aspect
      * @param includeGrouping
-     *            TODO
      * @return the list of network authorizations for this aspect
      */
     List<NetworkAuthorization<RuleForm>> getNetworkAuthorizations(Aspect<RuleForm> aspect,
@@ -593,7 +637,6 @@ public interface NetworkedModel<RuleForm extends ExistentialRuleform<RuleForm, N
      * deletions and modifications
      * 
      * @param initial
-     *            TODO
      *
      * @throws SQLException
      */

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
@@ -63,6 +63,7 @@ import com.chiralbehaviors.CoRE.ExistentialRuleform;
 import com.chiralbehaviors.CoRE.Ruleform;
 import com.chiralbehaviors.CoRE.Ruleform_;
 import com.chiralbehaviors.CoRE.agency.Agency;
+import com.chiralbehaviors.CoRE.agency.AgencyNetworkAuthorization;
 import com.chiralbehaviors.CoRE.attribute.Attribute;
 import com.chiralbehaviors.CoRE.attribute.AttributeAuthorization;
 import com.chiralbehaviors.CoRE.attribute.AttributeAuthorization_;
@@ -385,7 +386,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         if (checkCapability(current.getPrincipal(), stateAuth, capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkCapability(r.getClassification(), stateAuth, capability)) {
                 return true;
             }
@@ -400,7 +401,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         if (checkCapability(current.getPrincipal(), instance, capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkCapability(r.getClassification(), instance, capability)) {
                 return true;
             }
@@ -415,7 +416,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         if (checkCapability(current.getPrincipal(), auth, capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkCapability(r.getClassification(), auth, capability)) {
                 return true;
             }
@@ -430,7 +431,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         if (checkCapability(current.getPrincipal(), stateAuth, capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkCapability(r.getClassification(), stateAuth, capability)) {
                 return true;
             }
@@ -445,7 +446,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         if (checkCapability(current.getPrincipal(), stateAuth, capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkCapability(r.getClassification(), stateAuth, capability)) {
                 return true;
             }
@@ -491,7 +492,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         if (checkFacetCapability(current.getPrincipal(), facet, capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkFacetCapability(r.getClassification(), facet,
                                      capability)) {
                 return true;
@@ -538,7 +539,7 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
                                    capability)) {
             return true;
         }
-        for (Aspect<Agency> r : current.getActiveRoles()) {
+        for (AgencyNetworkAuthorization r : current.getActiveRoles()) {
             if (checkNetworkCapability(r.getClassification(), stateAuth,
                                        capability)) {
                 return true;

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/meta/models/AbstractNetworkedModel.java
@@ -81,6 +81,7 @@ import com.chiralbehaviors.CoRE.network.NetworkRuleform;
 import com.chiralbehaviors.CoRE.network.XDomainNetworkAuthorization;
 import com.chiralbehaviors.CoRE.product.Product;
 import com.chiralbehaviors.CoRE.relationship.Relationship;
+import com.chiralbehaviors.CoRE.security.AuthorizedPrincipal;
 import com.chiralbehaviors.CoRE.workspace.WorkspaceAuthorization;
 import com.chiralbehaviors.CoRE.workspace.WorkspaceAuthorization_;
 import com.hellblazer.utils.Tuple;
@@ -377,6 +378,81 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
                     .isEmpty();
     }
 
+    @Override
+    public boolean checkCapability(AttributeAuthorization<RuleForm, ?> stateAuth,
+                                   Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkCapability(current.getPrincipal(), stateAuth, capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkCapability(r.getClassification(), stateAuth, capability)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checkCapability(ExistentialRuleform<?, ?> instance,
+                                   Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkCapability(current.getPrincipal(), instance, capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkCapability(r.getClassification(), instance, capability)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checkCapability(NetworkAuthorization<RuleForm> auth,
+                                   Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkCapability(current.getPrincipal(), auth, capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkCapability(r.getClassification(), auth, capability)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checkCapability(XDomainAttrbuteAuthorization<?, ?> stateAuth,
+                                   Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkCapability(current.getPrincipal(), stateAuth, capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkCapability(r.getClassification(), stateAuth, capability)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checkCapability(XDomainNetworkAuthorization<?, ?> stateAuth,
+                                   Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkCapability(current.getPrincipal(), stateAuth, capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkCapability(r.getClassification(), stateAuth, capability)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Check the capability of an agency on the facet.
      */
@@ -408,6 +484,22 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
                     .isEmpty();
     }
 
+    @Override
+    public boolean checkFacetCapability(NetworkAuthorization<RuleForm> facet,
+                                        Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkFacetCapability(current.getPrincipal(), facet, capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkFacetCapability(r.getClassification(), facet,
+                                     capability)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Check the capability of an agency on an attribute of the authorized
      * relationship of the facet child relationship.
@@ -436,6 +528,23 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
         query.setParameter("capability", capability);
         return query.getResultList()
                     .isEmpty();
+    }
+
+    @Override
+    public boolean checkNetworkCapability(AttributeAuthorization<RuleForm, ?> stateAuth,
+                                          Relationship capability) {
+        AuthorizedPrincipal current = model.getCurrentPrincipal();
+        if (checkNetworkCapability(current.getPrincipal(), stateAuth,
+                                   capability)) {
+            return true;
+        }
+        for (Aspect<Agency> r : current.getActiveRoles()) {
+            if (checkNetworkCapability(r.getClassification(), stateAuth,
+                                       capability)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -1625,8 +1734,6 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
 
     abstract protected Class<?> getAttributeAuthorizationClass();
 
-    abstract protected Class<?> getNetworkAuthClass();
-
     protected NetworkRuleform<RuleForm> getImmediateLink(RuleForm parent,
                                                          Relationship relationship) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -1644,4 +1751,6 @@ abstract public class AbstractNetworkedModel<RuleForm extends ExistentialRulefor
             return null;
         }
     }
+
+    abstract protected Class<?> getNetworkAuthClass();
 }

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/phantasm/model/PhantasmCRUD.java
@@ -275,9 +275,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 facet, getAPPLY())) {
+        if (!networkedModel.checkFacetCapability(facet, getAPPLY())) {
             return instance;
         }
         networkedModel.initialize(instance, model.getEntityManager()
@@ -339,12 +337,10 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
 
     public boolean checkInvoke(NetworkAuthorization<RuleForm> facet,
                                RuleForm instance) {
-        Agency principal = model.getCurrentPrincipal()
-                                .getPrincipal();
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         Relationship invoke = getINVOKE();
-        return networkedModel.checkCapability(principal, instance, invoke)
-               && networkedModel.checkFacetCapability(principal, facet, invoke);
+        return networkedModel.checkCapability(instance, invoke)
+               && networkedModel.checkFacetCapability(facet, invoke);
     }
 
     /**
@@ -363,9 +359,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
                                    String name, String description,
                                    Function<RuleForm, RuleForm> constructor) {
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 facet, getCREATE())) {
+        if (!networkedModel.checkFacetCapability(facet, getCREATE())) {
             return null;
         }
         RuleForm instance;
@@ -458,9 +452,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
         return networkedModel.getChildren(instance, auth.getChildRelationship())
                              .stream()
-                             .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                                  .getPrincipal(),
-                                                                             child,
+                             .filter(child -> networkedModel.checkCapability(child,
                                                                              getREAD()))
                              .collect(Collectors.toList());
 
@@ -511,9 +503,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         }
         NetworkedModel<?, ?, ?, ?> childNetworkModel = model.getUnknownNetworkedModel(childAuthClassification);
         return result.stream()
-                     .filter(child -> childNetworkModel.checkCapability(model.getCurrentPrincipal()
-                                                                             .getPrincipal(),
-                                                                        child,
+                     .filter(child -> childNetworkModel.checkCapability(child,
                                                                         getREAD()))
                      .collect(Collectors.toList());
     }
@@ -549,9 +539,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return networkedModel.getImmediateChildren(instance,
                                                    auth.getChildRelationship())
                              .stream()
-                             .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                                  .getPrincipal(),
-                                                                             child,
+                             .filter(child -> networkedModel.checkCapability(child,
                                                                              getREAD()))
                              .collect(Collectors.toList());
     }
@@ -564,9 +552,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
      */
     public List<RuleForm> getInstances(NetworkAuthorization<RuleForm> facet) {
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 facet, getREAD())) {
+        if (!networkedModel.checkFacetCapability(facet, getREAD())) {
             return Collections.emptyList();
         }
         return networkedModel.getChildren(facet.getClassification(),
@@ -678,9 +664,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return ids.stream()
                   .map(id -> networkedModel.find(UUID.fromString(id)))
                   .filter(rf -> rf != null)
-                  .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                       .getPrincipal(),
-                                                                  child,
+                  .filter(child -> networkedModel.checkCapability(child,
                                                                   getREAD()))
                   .collect(Collectors.toList());
     }
@@ -690,9 +674,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         NetworkedModel<?, ?, ?, ?> networkedModel = model.getUnknownNetworkedModel(auth.getClassification());
         return Optional.of(networkedModel.find(UUID.fromString(id)))
                        .filter(rf -> rf != null)
-                       .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                            .getPrincipal(),
-                                                                       child,
+                       .filter(child -> networkedModel.checkCapability(child,
                                                                        getREAD()))
                        .get();
     }
@@ -703,9 +685,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
         return ids.stream()
                   .map(id -> networkedModel.find(UUID.fromString(id)))
                   .filter(rf -> rf != null)
-                  .filter(child -> networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                                       .getPrincipal(),
-                                                                  child,
+                  .filter(child -> networkedModel.checkCapability(child,
                                                                   getREAD()))
                   .collect(Collectors.toList());
     }
@@ -725,9 +705,7 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
             return null;
         }
         NetworkedModel<RuleForm, ?, ?, ?> networkedModel = model.getNetworkedModel(facet.getClassification());
-        if (!networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                      .getPrincipal(),
-                                                 facet, getREMOVE())) {
+        if (!networkedModel.checkFacetCapability(facet, getREMOVE())) {
             return instance;
         }
         networkedModel.initialize(instance, facet, model.getCurrentPrincipal()
@@ -1147,65 +1125,47 @@ public class PhantasmCRUD<RuleForm extends ExistentialRuleform<RuleForm, Network
 
     private boolean checkREAD(AttributeAuthorization<RuleForm, Network> stateAuth,
                               NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              stateAuth, getREAD());
+        return networkedModel.checkCapability(stateAuth, getREAD());
     }
 
     private boolean checkREAD(@SuppressWarnings("rawtypes") ExistentialRuleform child,
                               NetworkedModel<?, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              child, getREAD());
+        return networkedModel.checkCapability(child, getREAD());
     }
 
     private boolean checkREAD(NetworkAuthorization<RuleForm> auth,
                               NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        return networkedModel.checkFacetCapability(model.getCurrentPrincipal()
-                                                        .getPrincipal(),
-                                                   auth, getREAD());
+        return networkedModel.checkFacetCapability(auth, getREAD());
     }
 
     private boolean checkREAD(NetworkedModel<RuleForm, ?, ?, ?> networkedModel,
                               RuleForm instance) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              instance, getREAD());
+        return networkedModel.checkCapability(instance, getREAD());
     }
 
     private boolean checkREAD(XDomainNetworkAuthorization<?, ?> auth,
                               NetworkedModel<?, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              auth, getREAD());
+        return networkedModel.checkCapability(auth, getREAD());
     }
 
     private boolean checkUPDATE(AttributeAuthorization<RuleForm, Network> stateAuth,
                                 NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              stateAuth, getUPDATE());
+        return networkedModel.checkCapability(stateAuth, getUPDATE());
     }
 
     private boolean checkUPDATE(@SuppressWarnings("rawtypes") ExistentialRuleform child,
                                 NetworkedModel<?, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              child, getUPDATE());
+        return networkedModel.checkCapability(child, getUPDATE());
     }
 
     private boolean checkUPDATE(NetworkAuthorization<RuleForm> auth,
                                 NetworkedModel<RuleForm, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              auth, getUPDATE());
+        return networkedModel.checkCapability(auth, getUPDATE());
     }
 
     private boolean checkUPDATE(XDomainNetworkAuthorization<?, ?> auth,
                                 NetworkedModel<?, ?, ?, ?> networkedModel) {
-        return networkedModel.checkCapability(model.getCurrentPrincipal()
-                                                   .getPrincipal(),
-                                              auth, getUPDATE());
+        return networkedModel.checkCapability(auth, getUPDATE());
     }
 
     private Object[] getIndexedAttributeValue(RuleForm instance,

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/security/AuthorizedPrincipal.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/security/AuthorizedPrincipal.java
@@ -20,8 +20,10 @@
 
 package com.chiralbehaviors.CoRE.security;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.chiralbehaviors.CoRE.agency.Agency;
 import com.chiralbehaviors.CoRE.agency.AgencyNetworkAuthorization;
@@ -35,6 +37,7 @@ import com.chiralbehaviors.CoRE.agency.AgencyNetworkAuthorization;
  */
 public class AuthorizedPrincipal implements Cloneable {
     private final List<AgencyNetworkAuthorization> activeRoles;
+    private final List<Agency>                     capabilities;
     private final Agency                           principal;
 
     /**
@@ -51,7 +54,11 @@ public class AuthorizedPrincipal implements Cloneable {
     public AuthorizedPrincipal(Agency principal,
                                List<AgencyNetworkAuthorization> activeRoles) {
         this.principal = principal;
-        this.activeRoles = Collections.unmodifiableList(activeRoles);
+        this.activeRoles = new ArrayList<>(activeRoles);
+        capabilities = this.activeRoles.stream()
+                                       .map(auth -> auth.getClassification())
+                                       .collect(Collectors.toList());
+        capabilities.add(0, this.principal);
     }
 
     public List<AgencyNetworkAuthorization> getActiveRoles() {
@@ -60,5 +67,9 @@ public class AuthorizedPrincipal implements Cloneable {
 
     public Agency getPrincipal() {
         return principal;
+    }
+
+    public List<Agency> getCapabilities() {
+        return capabilities;
     }
 }

--- a/animations/src/main/java/com/chiralbehaviors/CoRE/security/AuthorizedPrincipal.java
+++ b/animations/src/main/java/com/chiralbehaviors/CoRE/security/AuthorizedPrincipal.java
@@ -23,10 +23,8 @@ package com.chiralbehaviors.CoRE.security;
 import java.util.Collections;
 import java.util.List;
 
-import javax.persistence.EntityManager;
-
 import com.chiralbehaviors.CoRE.agency.Agency;
-import com.chiralbehaviors.CoRE.meta.Aspect;
+import com.chiralbehaviors.CoRE.agency.AgencyNetworkAuthorization;
 
 /**
  * Represents the Agency and the authorized active aspects the principal has
@@ -36,14 +34,14 @@ import com.chiralbehaviors.CoRE.meta.Aspect;
  *
  */
 public class AuthorizedPrincipal implements Cloneable {
-    private final List<Aspect<Agency>> activeRoles;
-    private final Agency               principal;
+    private final List<AgencyNetworkAuthorization> activeRoles;
+    private final Agency                           principal;
 
     /**
      * @param principal
      */
     public AuthorizedPrincipal(Agency principal) {
-        this(principal, Collections.<Aspect<Agency>> emptyList());
+        this(principal, Collections.<AgencyNetworkAuthorization> emptyList());
     }
 
     /**
@@ -51,21 +49,16 @@ public class AuthorizedPrincipal implements Cloneable {
      * @param activeRoles
      */
     public AuthorizedPrincipal(Agency principal,
-                               List<Aspect<Agency>> activeRoles) {
+                               List<AgencyNetworkAuthorization> activeRoles) {
         this.principal = principal;
         this.activeRoles = Collections.unmodifiableList(activeRoles);
     }
 
-    public List<Aspect<Agency>> getActiveRoles() {
+    public List<AgencyNetworkAuthorization> getActiveRoles() {
         return activeRoles;
     }
 
     public Agency getPrincipal() {
         return principal;
-    }
-
-    public AuthorizedPrincipal merge(EntityManager em) {
-        return new AuthorizedPrincipal(em.getReference(Agency.class,
-                                                       principal.getId()));
     }
 }

--- a/animations/src/test/java/com/chiralbehaviors/CoRE/phantasm/TestPhantasm.java
+++ b/animations/src/test/java/com/chiralbehaviors/CoRE/phantasm/TestPhantasm.java
@@ -20,6 +20,7 @@
 
 package com.chiralbehaviors.CoRE.phantasm;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -103,7 +104,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         ProductAttributeAuthorization accessAuth = new ProductAttributeAuthorization(kernel.getCore());
@@ -113,7 +114,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -121,7 +122,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         accessAuth = new ProductAttributeAuthorization(kernel.getCore());
@@ -131,7 +132,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -139,7 +140,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
     }
 
@@ -169,7 +170,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         ProductNetworkAuthorization accessAuth = new ProductNetworkAuthorization(kernel.getCore());
@@ -182,7 +183,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -190,7 +191,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         accessAuth = new ProductNetworkAuthorization(kernel.getCore());
@@ -203,7 +204,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -211,7 +212,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
     }
 
@@ -340,7 +341,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(facet);
 
         assertTrue(model.getProductModel()
-                        .checkFacetCapability(kernel.getCore(), facet,
+                        .checkFacetCapability(asList(kernel.getCore()), facet,
                                               kernel.getHadMember()));
 
         ProductNetworkAuthorization accessAuth = new ProductNetworkAuthorization(kernel.getCore());
@@ -350,7 +351,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkFacetCapability(kernel.getCore(), facet,
+                         .checkFacetCapability(asList(kernel.getCore()), facet,
                                                kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -358,7 +359,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkFacetCapability(kernel.getCore(), facet,
+                        .checkFacetCapability(asList(kernel.getCore()), facet,
                                               kernel.getHadMember()));
 
         accessAuth = new ProductNetworkAuthorization(kernel.getCore());
@@ -368,7 +369,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkFacetCapability(kernel.getCore(), facet,
+                         .checkFacetCapability(asList(kernel.getCore()), facet,
                                                kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -376,7 +377,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkFacetCapability(kernel.getCore(), facet,
+                        .checkFacetCapability(asList(kernel.getCore()), facet,
                                               kernel.getHadMember()));
     }
 
@@ -386,7 +387,7 @@ public class TestPhantasm extends AbstractModelTest {
 
         Product instance = thing1.getRuleform();
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), instance,
+                        .checkCapability(asList(kernel.getCore()), instance,
                                          kernel.getHadMember()));
 
         AgencyProductGrouping accessAuth = new AgencyProductGrouping();
@@ -396,7 +397,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), instance,
+                         .checkCapability(asList(kernel.getCore()), instance,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -404,7 +405,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), instance,
+                        .checkCapability(asList(kernel.getCore()), instance,
                                          kernel.getHadMember()));
 
         accessAuth = new AgencyProductGrouping();
@@ -414,7 +415,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), instance,
+                         .checkCapability(asList(kernel.getCore()), instance,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -422,7 +423,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), instance,
+                        .checkCapability(asList(kernel.getCore()), instance,
                                          kernel.getHadMember()));
     }
 
@@ -461,7 +462,8 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertTrue(model.getProductModel()
-                        .checkNetworkCapability(kernel.getCore(), stateAuth,
+                        .checkNetworkCapability(asList(kernel.getCore()),
+                                                stateAuth,
                                                 kernel.getHadMember()));
 
         ProductAttributeAuthorization accessAuth = new ProductAttributeAuthorization(kernel.getCore());
@@ -471,7 +473,8 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkNetworkCapability(kernel.getCore(), stateAuth,
+                         .checkNetworkCapability(asList(kernel.getCore()),
+                                                 stateAuth,
                                                  kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -479,7 +482,8 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkNetworkCapability(kernel.getCore(), stateAuth,
+                        .checkNetworkCapability(asList(kernel.getCore()),
+                                                stateAuth,
                                                 kernel.getHadMember()));
 
         accessAuth = new ProductAttributeAuthorization(kernel.getCore());
@@ -489,7 +493,8 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkNetworkCapability(kernel.getCore(), stateAuth,
+                         .checkNetworkCapability(asList(kernel.getCore()),
+                                                 stateAuth,
                                                  kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -497,7 +502,8 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkNetworkCapability(kernel.getCore(), stateAuth,
+                        .checkNetworkCapability(asList(kernel.getCore()),
+                                                stateAuth,
                                                 kernel.getHadMember()));
     }
 
@@ -540,7 +546,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         ProductLocationAuthorization accessAuth = new ProductLocationAuthorization(kernel.getCore());
@@ -555,7 +561,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -563,7 +569,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         accessAuth = new ProductLocationAuthorization(kernel.getCore());
@@ -578,7 +584,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -586,7 +592,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
     }
 
@@ -606,7 +612,7 @@ public class TestPhantasm extends AbstractModelTest {
         assertNotNull(stateAuth);
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         ProductLocationAttributeAuthorization accessAuth = new ProductLocationAttributeAuthorization(kernel.getCore());
@@ -616,7 +622,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -624,7 +630,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getAnyAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
 
         accessAuth = new ProductLocationAttributeAuthorization(kernel.getCore());
@@ -634,7 +640,7 @@ public class TestPhantasm extends AbstractModelTest {
         em.persist(accessAuth);
 
         assertFalse(model.getProductModel()
-                         .checkCapability(kernel.getCore(), stateAuth,
+                         .checkCapability(asList(kernel.getCore()), stateAuth,
                                           kernel.getHadMember()));
 
         model.getAgencyModel()
@@ -642,7 +648,7 @@ public class TestPhantasm extends AbstractModelTest {
                    kernel.getSameAgency(), kernel.getCore());
 
         assertTrue(model.getProductModel()
-                        .checkCapability(kernel.getCore(), stateAuth,
+                        .checkCapability(asList(kernel.getCore()), stateAuth,
                                          kernel.getHadMember()));
     }
 

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/graphql/FacetType.java
@@ -50,7 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.chiralbehaviors.CoRE.ExistentialRuleform;
-import com.chiralbehaviors.CoRE.agency.Agency;
 import com.chiralbehaviors.CoRE.attribute.Attribute;
 import com.chiralbehaviors.CoRE.attribute.AttributeAuthorization;
 import com.chiralbehaviors.CoRE.kernel.product.Constructor;
@@ -645,10 +644,7 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                 PhantasmCRUD<RuleForm, Network> crud) {
         return crud.getModel()
                    .getProductModel()
-                   .checkCapability(crud.getModel()
-                                        .getCurrentPrincipal()
-                                        .getPrincipal(),
-                                    constructor.getRuleform(),
+                   .checkCapability(constructor.getRuleform(),
                                     crud.getINVOKE());
     }
 
@@ -656,12 +652,9 @@ public class FacetType<RuleForm extends ExistentialRuleform<RuleForm, Network>, 
                                 InstanceMethod method, RuleForm instance,
                                 PhantasmCRUD<RuleForm, Network> crud) {
         Model model = crud.getModel();
-        Agency principal = model.getCurrentPrincipal()
-                                .getPrincipal();
         NetworkedModel<RuleForm, Network, ?, ?> networkedModel = model.getNetworkedModel(instance);
         Relationship invoke = crud.getINVOKE();
-        return networkedModel.checkCapability(principal, method.getRuleform(),
-                                              invoke)
+        return networkedModel.checkCapability(method.getRuleform(), invoke)
                && crud.checkInvoke(facet, instance);
     }
 

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/resources/GraphQlResource.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/resources/GraphQlResource.java
@@ -195,13 +195,13 @@ public class GraphQlResource extends TransactionalResource {
             PhantasmCRUD crud = new PhantasmCRUD(model);
             Product definingProduct = model.getEntityManager()
                                            .find(Product.class, uuid);
-            Agency p = model.getCurrentPrincipal()
-                            .getPrincipal();
             if (!model.getNetworkedModel(definingProduct)
-                      .checkCapability(p, definingProduct, crud.getREAD())
+                      .checkCapability(definingProduct, crud.getREAD())
                 || !model.getNetworkedModel(definingProduct)
-                         .checkCapability(p, definingProduct, model.getKernel()
-                                                                   .getEXECUTE_QUERY())) {
+                         .checkCapability(definingProduct, model.getKernel()
+                                                                .getEXECUTE_QUERY())) {
+                Agency p = model.getCurrentPrincipal()
+                                .getPrincipal();
                 log.info(String.format("Failed executing query on workspace [%s:%s] by: %s:%s",
                                        definingProduct.getName(), uuid,
                                        p.getName(), p.getId()));

--- a/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/resources/TransactionalResource.java
+++ b/phantasm-at-rest/src/main/java/com/chiralbehaviors/CoRE/phantasm/resources/TransactionalResource.java
@@ -106,8 +106,6 @@ public class TransactionalResource {
         if (principal == null) {
             principal = new AuthorizedPrincipal(model.getKernel()
                                                      .getUnauthenticatedAgency());
-        } else {
-            principal = principal.merge(em);
         }
         try {
             return model.executeAs(principal, () -> {
@@ -144,8 +142,6 @@ public class TransactionalResource {
         if (principal == null) {
             principal = new AuthorizedPrincipal(model.getKernel()
                                                      .getUnauthenticatedAgency());
-        } else {
-            principal = principal.merge(em);
         }
         try {
             return model.executeAs(principal, () -> {


### PR DESCRIPTION
Issue https://github.com/ChiralBehaviors/Ultrastructure/issues/160

Use active roles asserted by the authorized principal.  Capabilities are OR'd across all asserted roles and the authenticated principal.  Previously, only the authenticated principal was used in the capability check.